### PR TITLE
Changes chunk already attached response to success

### DIFF
--- a/broker-node/app/Http/Controllers/UploadSessionController.php
+++ b/broker-node/app/Http/Controllers/UploadSessionController.php
@@ -114,7 +114,7 @@ class UploadSessionController extends Controller
 
         switch($data_map->processChunk()) {
             case 'already_attached':
-                return response('Error: Chunk already attached.', 500);
+                return response('Chunk already attached.', 204);
             case 'hooknode_unavailable':
                 return response('Processing: Hooknodes are busy', 102);
             case 'success':


### PR DESCRIPTION
This is so we don't error out, if we send to two brokers.