### PR TITLE
Rfornea patch chunk events

### DIFF
--- a/broker-node/app/ChunkEvents.php
+++ b/broker-node/app/ChunkEvents.php
@@ -1,34 +1,20 @@
 <?php
 
-
 namespace App;
 
-
-
 use App\Clients\BrokerNode;
-
 use Illuminate\Database\Eloquent\Model;
-
 use Webpatser\Uuid\Uuid;
 
-
-
 class ChunkEvents extends Model
-
 {
-    
-    
     public static function boot()
     {
-        
         parent::boot();
-        
         self::creating(function ($model) {
-            
             $model->id = (string)Uuid::generate(4);
-            
         });
-            
+    }
 
     protected $table = 'chunk_events';
     protected $fillable = [
@@ -38,29 +24,16 @@ class ChunkEvents extends Model
         'value'
     ];
     public $incrementing = false;  // UUID
-    
-    
-    public static function addChunkEvent($event_name, $hooknode_id, $session_id, $value){
-        
+
+    public static function addChunkEvent($event_name, $hooknode_id, $session_id, $value)
+    {
         self::create([
-            
             'hooknode_id' => $hooknode_id,
-            
             'session_id' => $session_id,
-            
             'event_name' => $event_name,
-            
             'value' => $value
-            
         ]);
-        
+
         //$this->save();
-        
     }
-    
-
-
 }
-
-
-?>

--- a/broker-node/app/Clients/BrokerNode.php
+++ b/broker-node/app/Clients/BrokerNode.php
@@ -25,11 +25,9 @@ class BrokerNode
 
     public static $IriWrapper = null;
     public static $NodeMessenger = null;
-    
-    
-    
-    public static $ChunkEventsRecord  = null;
-    
+
+
+    public static $ChunkEventsRecord = null;
 
 
     // Hack to load balance across hooknodes.
@@ -42,14 +40,14 @@ class BrokerNode
             self::$IriWrapper = new IriWrapper();
         }
     }
-    
+
     private static function initEventRecord()
     {
         if (is_null(self::$ChunkEventsRecord)) {
             self::$ChunkEventsRecord = new ChunkEvents();
         }
     }
-    
+
 
     private static function initMessenger()
     {
@@ -273,7 +271,7 @@ class BrokerNode
 
         $next = array_rand($nodes);
 
-        return "http://" . $nodes[$next] . ":250/HookListener.php";
+        return $nodes[$next];
     }
 
     public static function processChunks(&$chunks)
@@ -436,19 +434,19 @@ class BrokerNode
         self::initMessenger();
         //self::$NodeMessenger->sendMessageToNode($tx, $hookNodeUrl);
 
-        $spammedNodes = array($hookNodeUrl);   //temporary solution
+        $spammedNodes = array("http://" . $hookNodeUrl . ":250/HookListener.php");   //temporary solution
         for ($i = 0; $i <= 1; $i++) {   //temporary solution
-            $spammedNodes[] = self::selectHookNode()['ip_address'];
+            $spammedNodes[] = "http://" . self::selectHookNode()['ip_address'] . ":250/HookListener.php";
         }
 
         self::$NodeMessenger->spamHookNodes($tx, $spammedNodes);  // remove this, temporary solution
 
         self::updateHookNodeDirectory($hookNodeUrl, "request_made");
-        
+
         //record event
         self::initEventRecord();
         self::$ChunkEventsRecord->addChunkEvent("chunk_sent_to_hook", $hookNodeUrl, "todo", "todo");
-        
+
 
         array_walk($chunks, function ($chunk) use ($hookNodeUrl) {
             $chunk->hookNodeUrl = $hookNodeUrl;

--- a/broker-node/database/migrations/2018_01_28_155850_create_hook_nodes_table.php
+++ b/broker-node/database/migrations/2018_01_28_155850_create_hook_nodes_table.php
@@ -31,6 +31,7 @@ class CreateHookNodesTable extends Migration
 
             // Indexes
             $table->primary('id');
+            $table->unique(['ip_address']);
         });
     }
 

--- a/broker-node/database/migrations/2018_02_05_200133_create_chunk_events_table.php
+++ b/broker-node/database/migrations/2018_02_05_200133_create_chunk_events_table.php
@@ -13,16 +13,19 @@ class CreateChunkEventsTable extends Migration
      */
     public function up()
     {
-       Schema::create('chunk_events', function (Blueprint $table) {
-           $table->uuid('id');
-           $table->timestamps();
-           $table->string('hooknode_id');
-           $table->string('session_id');
-           $table->string('event_name');
-           $table->string('value');
-         });
+        Schema::create('chunk_events', function (Blueprint $table) {
+            $table->uuid('id');
+            $table->timestamps();
+            $table->string('hooknode_id');
+            $table->string('session_id');
+            $table->string('event_name');
+            $table->string('value');
 
-      }
+            // Indexes
+            $table->primary('id');
+            $table->unique(['id']);
+        });
+    }
 
     /**
      * Reverse the migrations.
@@ -34,3 +37,4 @@ class CreateChunkEventsTable extends Migration
         Schema::dropIfExists('chunk_events');
     }
 }
+


### PR DESCRIPTION
- fixes syntax errors in ChunkEvents that were preventing chunk events recording from working
- updates BrokerNode file so that we no longer include 'http://' and ':250/HookListener.php' at the end of our hooknode ids in the databases
- adds a primary and unique key to the chunk events table to allow easy deleting with phpmyadmin