### PR TITLE
Testnet a patches

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ Desktop.ini
 !.htaccess
 !/.gitignore
 !/.travis.yml
+
+# Dependency directories
+node_modules/

--- a/broker-node/app/Clients/BrokerNode.php
+++ b/broker-node/app/Clients/BrokerNode.php
@@ -165,12 +165,12 @@ class BrokerNode
 
     private static function getTransactionsToApprove(&$request)
     {
-        $tips = Tips::getNextTips();
-
-        if ($tips != null && $tips[0] != null && $tips[1] != null) {
-            $request->trunkTransaction = $tips[1];
-            $request->branchTransaction = $tips[0];
-        } else {
+//        $tips = Tips::getNextTips();
+//
+//        if ($tips != null && $tips[0] != null && $tips[1] != null) {
+//            $request->trunkTransaction = $tips[1];
+//            $request->branchTransaction = $tips[0];
+//        } else {
             $command = new \stdClass();
             $command->command = "getTransactionsToApprove";
             $command->depth = IriData::$depthToSearchForTxs;
@@ -185,7 +185,7 @@ class BrokerNode
             } else {
                 throw new \Exception('getTransactionToApprove failed! ' . $result->error);
             }
-        }
+        //}
     }
 
     private static function selectHookNode()

--- a/broker-node/app/Clients/BrokerNode.php
+++ b/broker-node/app/Clients/BrokerNode.php
@@ -225,12 +225,6 @@ class BrokerNode
         $tx->command = 'attachToTangle';
         $tx->broadcastingNodes = $broadcastingNodes;
 
-        var_dump($broadcastingNodes);
-
-        $cmd = json_encode($tx);
-
-        echo $cmd;
-
         NodeMessenger::sendMessageToNodesAndContinue($tx, $hookNodes);
 
         //record event

--- a/broker-node/app/Clients/BrokerNode.php
+++ b/broker-node/app/Clients/BrokerNode.php
@@ -194,6 +194,20 @@ class BrokerNode
         return ['ip_address' => $nextNode->ip_address];
     }
 
+    private static function getBroadcastingHookNodes()
+    {
+        $ip_addresses = array();
+
+        $broadcastingNodes =
+            HookNode::getBroadcastingHookNodes(['score_weight' => .5]);
+
+        foreach ($broadcastingNodes as $node) {
+            $ip_addresses[] = $node->ip_address;
+        }
+
+        return $ip_addresses;
+    }
+
     private static function sendToHookNode(&$chunks, $request)
     {
         $hooknode = self::selectHookNode();
@@ -203,11 +217,19 @@ class BrokerNode
         }
 
         $hookNodeUrl = $hooknode['ip_address'];
+        $hookNodes = array("http://" . $hookNodeUrl . ":3000/");
+
+        $broadcastingNodes = self::getBroadcastingHookNodes();
 
         $tx = $request;
         $tx->command = 'attachToTangle';
+        $tx->broadcastingNodes = $broadcastingNodes;
 
-        $hookNodes = array("http://" . $hookNodeUrl . ":3000/");
+        var_dump($broadcastingNodes);
+
+        $cmd = json_encode($tx);
+
+        echo $cmd;
 
         NodeMessenger::sendMessageToNodesAndContinue($tx, $hookNodes);
 

--- a/broker-node/app/Console/Commands/GetFreshTips.php
+++ b/broker-node/app/Console/Commands/GetFreshTips.php
@@ -35,6 +35,7 @@ class GetFreshTips extends Command
         while (Carbon::now()->lt($processStopTime)) {
             self::getFreshTipsFromSelf();
             self::purgeOldTips($tipsThresholdTime);
+            sleep(5);
         }
     }
 

--- a/broker-node/app/Console/Commands/GetFreshTips.php
+++ b/broker-node/app/Console/Commands/GetFreshTips.php
@@ -14,7 +14,7 @@ class GetFreshTips extends Command
     const TIPS_THRESHOLD_SECONDS = 5;
     const PROCESS_RUN_TIME_SECONDS = 295;
 
-    const TIPS_QUANTITY = 100;
+    const TIPS_QUANTITY = 50;
 
     protected $signature = 'GetFreshTips:getTips';
     protected $description =

--- a/broker-node/app/Console/Kernel.php
+++ b/broker-node/app/Console/Kernel.php
@@ -28,9 +28,9 @@ class Kernel extends ConsoleKernel
             ->everyMinute()
             ->sendOutputTo('/var/CHUNKLOG');
 
-        $schedule->command('GetFreshTips:getTips')
-            ->everyFiveMinutes()
-            ->sendOutputTo('/var/TIPSLOG');
+//        $schedule->command('GetFreshTips:getTips')
+//            ->everyFiveMinutes()
+//            ->sendOutputTo('/var/TIPSLOG');
     }
 
     /**


### PR DESCRIPTION
-adds a getBroadcastingNodes method to HookNode.  Selects hooknodes similar to getNextReadyNode but with a lower score weight.  Does not update 'contacted_at' because we don't want the hooknodes to miss their chance of increasing their score just because they did a broadcast 
-passes that array of hooknodes to the hooknode who will perform attachToTangle.
-disables the TipSelection service.  It seems to be doing more harm than good.  It's slowing the broker down a lot, and the new changes to iota seem to be resulting in better tips.  
-in the cron job, only re-send chunks in batches of 10.  