### PR TITLE
Job runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The broker node uses Docker to spin up a go app, mysql, and private iota instanc
 
 ```bash
 # Starts the brokernode on port 3000
-docker-compose up —-build # This takes a few minutes when you first run it.
+docker-compose up --build # This takes a few minutes when you first run it.
 
 # Executing commands in the app container
 # Use `docker-compose exec YOUR_COMMAND`

--- a/actions/app.go
+++ b/actions/app.go
@@ -6,9 +6,9 @@ import (
 	"github.com/gobuffalo/buffalo/middleware/ssl"
 	"github.com/gobuffalo/envy"
 	"github.com/unrolled/secure"
-
 	"github.com/gobuffalo/x/sessions"
 	"github.com/oysterprotocol/brokernode/models"
+	"github.com/oysterprotocol/brokernode/jobs"
 	"github.com/rs/cors"
 )
 
@@ -30,6 +30,8 @@ func App() *buffalo.App {
 				cors.Default().Handler,
 			},
 			SessionName: "_brokernode_session",
+			WorkerOff: false,
+			Worker: jobs.OysterWorker,
 		})
 		// Automatically redirect to SSL
 		app.Use(ssl.ForceSSL(secure.Options{

--- a/jobs/flush_old_webnodes.go
+++ b/jobs/flush_old_webnodes.go
@@ -1,7 +1,6 @@
 package jobs
 
 import (
-	"fmt"
 	"github.com/getsentry/raven-go"
 	"github.com/oysterprotocol/brokernode/models"
 	"time"
@@ -17,9 +16,7 @@ func FlushOldWebNodes(thresholdTime time.Time) {
 
 	if err != nil {
 		raven.CaptureError(err, nil)
-		fmt.Printf("%v\n", err)
 	} else {
-		fmt.Print("Success!\n")
 		for i := 0; i < len(webnodes); i++ {
 			webnode := webnodes[i]
 			models.DB.Destroy(&webnode)

--- a/jobs/job_runner.go
+++ b/jobs/job_runner.go
@@ -65,7 +65,7 @@ func doWork(oysterWorker *worker.Simple) {
 }
 
 var flushOldWebnodesHandler = func(args worker.Args) error {
-	thresholdTime := time.Now()
+	thresholdTime := time.Now().Add(-20 * time.Minute) // webnodes older than 20 minutes get deleted
 	FlushOldWebNodes(thresholdTime)
 
 	flushOldWebnodesJob := worker.Job{

--- a/jobs/job_runner.go
+++ b/jobs/job_runner.go
@@ -1,27 +1,118 @@
 package jobs
 
 import (
-	"fmt"
-	"github.com/oysterprotocol/brokernode/models"
 	"github.com/oysterprotocol/brokernode/services"
+	"github.com/gobuffalo/buffalo/worker"
+	"time"
 )
 
 var BundleSize = 10
 
-type ProcessChunksFunc func(dataMaps []models.DataMap)
+var OysterWorker = worker.NewSimple()
 
-type ChunkProcessor struct {
-	processChunks ProcessChunksFunc
-}
-
-var IotaWrapper services.IotaService
+var IotaWrapper = services.IotaWrapper
 
 func init() {
-	NewChunkProcessor(processChunks)
-	IotaWrapper := services.IotaWrapper
-	fmt.Println(IotaWrapper)
+	registerHandlers(OysterWorker)
+
+	doWork(OysterWorker)
 }
 
-func NewChunkProcessor(processChunks ProcessChunksFunc) *ChunkProcessor {
-	return &ChunkProcessor{processChunks: processChunks}
+func registerHandlers(oysterWorker *worker.Simple) {
+	oysterWorker.Register("flushOldWebnodesHandler", flushOldWebnodesHandler)
+	oysterWorker.Register("processUnassignedChunksHandler", processUnassignedChunksHandler)
+	oysterWorker.Register("purgeCompletedSessionsHandler", purgeCompletedSessionsHandler)
+	oysterWorker.Register("verifyDataMapsHandler", verifyDataMapsHandler)
+}
+
+func doWork(oysterWorker *worker.Simple) {
+	flushOldWebnodesJob := worker.Job{
+		Queue:   "default",
+		Handler: "flushOldWebnodesHandler",
+		Args: worker.Args{
+			"duration": 1 * time.Minute,
+		},
+	}
+
+	processUnassignedChunksJob := worker.Job{
+		Queue:   "default",
+		Handler: "processUnassignedChunksHandler",
+		Args: worker.Args{
+			"duration": 1 * time.Minute,
+		},
+	}
+
+	purgeCompletedSessionsJob := worker.Job{
+		Queue:   "default",
+		Handler: "purgeCompletedSessionsHandler",
+		Args: worker.Args{
+			"duration": 1 * time.Minute,
+		},
+	}
+
+	verifyDataMapsJob := worker.Job{
+		Queue:   "default",
+		Handler: "verifyDataMapsHandler",
+		Args: worker.Args{
+			"duration": 1 * time.Minute,
+		},
+	}
+
+	oysterWorker.PerformIn(flushOldWebnodesJob, flushOldWebnodesJob.Args["duration"].(time.Duration))
+	oysterWorker.PerformIn(processUnassignedChunksJob, processUnassignedChunksJob.Args["duration"].(time.Duration))
+	oysterWorker.PerformIn(purgeCompletedSessionsJob, purgeCompletedSessionsJob.Args["duration"].(time.Duration))
+	oysterWorker.PerformIn(verifyDataMapsJob, verifyDataMapsJob.Args["duration"].(time.Duration))
+}
+
+var flushOldWebnodesHandler = func(args worker.Args) error {
+	thresholdTime := time.Now()
+	FlushOldWebNodes(thresholdTime)
+
+	flushOldWebnodesJob := worker.Job{
+		Queue:   "default",
+		Handler: "flushOldWebnodesHandler",
+		Args:    args,
+	}
+	OysterWorker.PerformIn(flushOldWebnodesJob, flushOldWebnodesJob.Args["duration"].(time.Duration))
+
+	return nil
+}
+
+var processUnassignedChunksHandler = func(args worker.Args) error {
+	ProcessUnassignedChunks(IotaWrapper)
+
+	processUnassignedChunksJob := worker.Job{
+		Queue:   "default",
+		Handler: "processUnassignedChunksHandler",
+		Args:    args,
+	}
+	OysterWorker.PerformIn(processUnassignedChunksJob, processUnassignedChunksJob.Args["duration"].(time.Duration))
+
+	return nil
+}
+
+var purgeCompletedSessionsHandler = func(args worker.Args) error {
+	PurgeCompletedSessions()
+
+	purgeCompletedSessionsJob := worker.Job{
+		Queue:   "default",
+		Handler: "purgeCompletedSessionsHandler",
+		Args:    args,
+	}
+	OysterWorker.PerformIn(purgeCompletedSessionsJob, purgeCompletedSessionsJob.Args["duration"].(time.Duration))
+
+	return nil
+}
+
+var verifyDataMapsHandler = func(args worker.Args) error {
+	VerifyDataMaps(IotaWrapper)
+
+	verifyDataMapsJob := worker.Job{
+		Queue:   "default",
+		Handler: "verifyDataMapsHandler",
+		Args:    args,
+	}
+	OysterWorker.PerformIn(verifyDataMapsJob, verifyDataMapsJob.Args["duration"].(time.Duration))
+
+	return nil
 }

--- a/jobs/job_runner_test.go
+++ b/jobs/job_runner_test.go
@@ -27,21 +27,21 @@ func (suite *JobsSuite) SetupSuite() {
 		},
 		VerifyChunkMessagesMatchRecord: func(chunks []models.DataMap) (filteredChunks services.FilteredChunk, err error) {
 
-			emtpyChunkArray := []models.DataMap{}
+			emptyChunkArray := []models.DataMap{}
 
 			return services.FilteredChunk{
-				MatchesTangle:      emtpyChunkArray,
-				NotAttached:        emtpyChunkArray,
-				DoesNotMatchTangle: emtpyChunkArray,
+				MatchesTangle:      emptyChunkArray,
+				NotAttached:        emptyChunkArray,
+				DoesNotMatchTangle: emptyChunkArray,
 			}, err
 		},
 		VerifyChunksMatchRecord: func(chunks []models.DataMap, checkChunkAndBranch bool) (filteredChunks services.FilteredChunk, err error) {
-			emtpyChunkArray := []models.DataMap{}
+			emptyChunkArray := []models.DataMap{}
 
 			return services.FilteredChunk{
-				MatchesTangle:      emtpyChunkArray,
-				NotAttached:        emtpyChunkArray,
-				DoesNotMatchTangle: emtpyChunkArray,
+				MatchesTangle:      emptyChunkArray,
+				NotAttached:        emptyChunkArray,
+				DoesNotMatchTangle: emptyChunkArray,
 			}, err
 		},
 		ChunksMatch: func(chunkOnTangle giota.Transaction, chunkOnRecord models.DataMap, checkBranchAndTrunk bool) bool {

--- a/jobs/process_unassigned_chunks.go
+++ b/jobs/process_unassigned_chunks.go
@@ -4,25 +4,25 @@ import (
 	"fmt"
 	"github.com/getsentry/raven-go"
 	"github.com/oysterprotocol/brokernode/models"
+	"github.com/oysterprotocol/brokernode/services"
 )
 
 func init() {
 }
 
-func ProcessUnassignedChunks(processChunks ProcessChunksFunc) {
+func ProcessUnassignedChunks(iotaWrapper services.IotaService) {
 
 	chunks, err := GetUnassignedChunks()
 
 	if err != nil {
 		raven.CaptureError(err, nil)
 	} else {
-		processChunks(chunks)
+		iotaWrapper.ProcessChunks(chunks, false)
 	}
 }
 
 func GetUnassignedChunks() (dataMaps []models.DataMap, err error) {
 
-	//query := models.DB.Where("status = ? AND updated_at >= ?", strconv.Itoa(models.ChunkStatus["unassigned"]), thresholdTime)
 	query := models.DB.Where("status = ?", models.Unassigned)
 	dataMaps = []models.DataMap{}
 	err = query.All(&dataMaps)

--- a/jobs/process_unassigned_chunks.go
+++ b/jobs/process_unassigned_chunks.go
@@ -1,7 +1,6 @@
 package jobs
 
 import (
-	"fmt"
 	"github.com/getsentry/raven-go"
 	"github.com/oysterprotocol/brokernode/models"
 	"github.com/oysterprotocol/brokernode/services"
@@ -17,7 +16,18 @@ func ProcessUnassignedChunks(iotaWrapper services.IotaService) {
 	if err != nil {
 		raven.CaptureError(err, nil)
 	} else {
-		iotaWrapper.ProcessChunks(chunks, false)
+		if len(chunks) > 0 {
+
+			for i := 0; i < len(chunks); i += BundleSize {
+				end := i + BundleSize
+
+				if end > len(chunks) {
+					end = len(chunks)
+				}
+
+				iotaWrapper.ProcessChunks(chunks[i:end], false)
+			}
+		}
 	}
 }
 
@@ -28,26 +38,8 @@ func GetUnassignedChunks() (dataMaps []models.DataMap, err error) {
 	err = query.All(&dataMaps)
 	if err != nil {
 		raven.CaptureError(err, nil)
-		fmt.Printf("%v\n", err)
-	} else {
-		fmt.Print("Success!\n")
 	}
 
 	return dataMaps, err
 }
 
-func processChunks(dataMaps []models.DataMap) {
-	if len(dataMaps) > 0 {
-
-		for i := 0; i < len(dataMaps); i += BundleSize {
-			end := i + BundleSize
-
-			if end > len(dataMaps) {
-				end = len(dataMaps)
-			}
-
-			// send to broker code that processes these
-			//dataMaps[i:end]
-		}
-	}
-}

--- a/jobs/update_unverified_data_maps.go
+++ b/jobs/update_unverified_data_maps.go
@@ -1,1 +1,0 @@
-package jobs

--- a/jobs/update_unverified_data_maps_test.go
+++ b/jobs/update_unverified_data_maps_test.go
@@ -1,1 +1,0 @@
-package jobs

--- a/jobs/verify_data_maps.go
+++ b/jobs/verify_data_maps.go
@@ -1,7 +1,6 @@
 package jobs
 
 import (
-	"fmt"
 	"github.com/getsentry/raven-go"
 	"github.com/oysterprotocol/brokernode/models"
 	"github.com/oysterprotocol/brokernode/services"
@@ -37,7 +36,7 @@ func CheckChunks(IotaWrapper services.IotaService, unverifiedDataMaps []models.D
 	filteredChunks, err := IotaWrapper.VerifyChunkMessagesMatchRecord(unverifiedDataMaps)
 
 	if err != nil {
-		fmt.Println(err)
+		raven.CaptureError(err, nil)
 	}
 
 	if len(filteredChunks.MatchesTangle) > 0 {

--- a/main.go
+++ b/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"log"
-
 	"github.com/oysterprotocol/brokernode/actions"
 )
 

--- a/migrations/20180324202928_create_chunk_channels.down.fizz
+++ b/migrations/20180324202928_create_chunk_channels.down.fizz
@@ -1,0 +1,1 @@
+drop_table("chunk_channels")

--- a/migrations/20180324202928_create_chunk_channels.up.fizz
+++ b/migrations/20180324202928_create_chunk_channels.up.fizz
@@ -1,0 +1,8 @@
+create_table("chunk_channels", func(t) {
+	t.Column("id", "uuid", {"primary": true})
+	t.Column("channel_id", "string", {})
+	t.Column("chunks_processed", "int", {})
+	t.Column("est_ready_time", "timestamp", {"null": true})
+})
+
+add_index("chunk_channels", "channel_id", {"unique": true})

--- a/models/chunk_channels.go
+++ b/models/chunk_channels.go
@@ -1,0 +1,55 @@
+package models
+
+import (
+	"encoding/json"
+	"github.com/gobuffalo/pop"
+	"github.com/gobuffalo/uuid"
+	"github.com/gobuffalo/validate"
+	"time"
+)
+
+/*
+Intended to replace hooknodes table until we add hooknodes back in
+ */
+
+type ChunkChannel struct {
+	ID              uuid.UUID `json:"id" db:"id"`
+	ChannelID       string    `json:"channel_id" db:"channel_id"`
+	ChunksProcessed int       `json:"chunks_processed" db:"chunks_processed"`
+	EstReadyTime    time.Time `json:"est_ready_time" db:"est_ready_time"`
+	CreatedAt       time.Time `json:"created_at" db:"created_at"`
+	UpdatedAt       time.Time `json:"updated_at" db:"updated_at"`
+}
+
+// String is not required by pop and may be deleted
+func (c ChunkChannel) String() string {
+	jc, _ := json.Marshal(c)
+	return string(jc)
+}
+
+// ChunkChannels is not required by pop and may be deleted
+type ChunkChannels []ChunkChannel
+
+// String is not required by pop and may be deleted
+func (c ChunkChannels) String() string {
+	jc, _ := json.Marshal(c)
+	return string(jc)
+}
+
+// Validate gets run every time you call a "pop.Validate*" (pop.ValidateAndSave, pop.ValidateAndCreate, pop.ValidateAndUpdate) method.
+// This method is not required and may be deleted.
+func (c *ChunkChannel) Validate(tx *pop.Connection) (*validate.Errors, error) {
+	return validate.NewErrors(), nil
+}
+
+// ValidateCreate gets run every time you call "pop.ValidateAndCreate" method.
+// This method is not required and may be deleted.
+func (c *ChunkChannel) ValidateCreate(tx *pop.Connection) (*validate.Errors, error) {
+	return validate.NewErrors(), nil
+}
+
+// ValidateUpdate gets run every time you call "pop.ValidateAndUpdate" method.
+// This method is not required and may be deleted.
+func (c *ChunkChannel) ValidateUpdate(tx *pop.Connection) (*validate.Errors, error) {
+	return validate.NewErrors(), nil
+}

--- a/models/chunk_channels_test.go
+++ b/models/chunk_channels_test.go
@@ -1,0 +1,7 @@
+package models
+
+import "testing"
+
+func Test_ChunkChannel(t *testing.T) {
+	t.Log("Nothing to test yet")
+}

--- a/services/iota_wrappers.go
+++ b/services/iota_wrappers.go
@@ -4,22 +4,30 @@ import (
 	"fmt"
 	"github.com/iotaledger/giota"
 	"github.com/oysterprotocol/brokernode/models"
-	"os"
 	"strings"
 	"sync"
+	"runtime"
+	"github.com/getsentry/raven-go"
+	"time"
+	"math/rand"
 )
 
-type PowJob struct {
-	Transactions      []giota.Transaction
-	TrunkTransaction  giota.Trytes
-	BranchTransaction giota.Trytes
-	BroadcastNodes    []string
+type ChunkTracker struct {
+	ChunkCount  int
+	ElapsedTime time.Duration
 }
 
-type ProcessChunks func(chunks []models.DataMap, attachIfAlreadyAttached bool)
-type VerifyChunkMessagesMatchRecord func(chunks []models.DataMap) (filteredChunks FilteredChunk, err error)
-type VerifyChunksMatchRecord func(chunks []models.DataMap, checkChunkAndBranch bool) (filteredChunks FilteredChunk, err error)
-type ChunksMatch func(chunkOnTangle giota.Transaction, chunkOnRecord models.DataMap, checkBranchAndTrunk bool) bool
+type PowJob struct {
+	Chunks         []models.DataMap
+	BroadcastNodes []string
+}
+
+type PowChannel struct {
+	DBChannel     models.ChunkChannel
+	ChannelID     string
+	ChunkTrackers []ChunkTracker
+	Channel       chan PowJob
+}
 
 type IotaService struct {
 	ProcessChunks                  ProcessChunks
@@ -28,31 +36,39 @@ type IotaService struct {
 	ChunksMatch                    ChunksMatch
 }
 
+type ProcessChunks func(chunks []models.DataMap, attachIfAlreadyAttached bool)
+type VerifyChunkMessagesMatchRecord func(chunks []models.DataMap) (filteredChunks FilteredChunk, err error)
+type VerifyChunksMatchRecord func(chunks []models.DataMap, checkChunkAndBranch bool) (filteredChunks FilteredChunk, err error)
+type ChunksMatch func(chunkOnTangle giota.Transaction, chunkOnRecord models.DataMap, checkBranchAndTrunk bool) bool
+
 type FilteredChunk struct {
 	MatchesTangle      []models.DataMap
 	DoesNotMatchTangle []models.DataMap
 	NotAttached        []models.DataMap
 }
 
-var seed giota.Trytes
-
-var provider = os.Getenv("PROVIDER")
-var minDepth = int64(giota.DefaultNumberOfWalks)
-var minWeightMag = int64(1)
-
-var api = giota.NewAPI(provider, nil)
-var bestPow giota.PowFunc
-var powName string
-
 // Things below are copied from the giota lib since they are not public.
 // https://github.com/iotaledger/giota/blob/master/transfer.go#L322
+const (
+	maxTimestampTrytes = "MMMMMMMMM"
+)
 
-// (3^27-1)/2
-const maxTimestampTrytes = "MMMMMMMMM"
-
-// This mutex was added by us.
-var mutex = &sync.Mutex{}
-var IotaWrapper IotaService
+var (
+	// PowProcs is number of concurrent processes (default is NumCPU()-1)
+	PowProcs    int
+	IotaWrapper IotaService
+	//This mutex was added by us.
+	mutex        = &sync.Mutex{}
+	seed         giota.Trytes
+	provider     = "http://172.21.0.1:14265"
+	minDepth     = int64(giota.DefaultNumberOfWalks)
+	minWeightMag = int64(14)
+	api          = giota.NewAPI(provider, nil)
+	bestPow      giota.PowFunc
+	powName      string
+	letters      = []rune("ABCDEFGHIJKLMNOPQRSTUVWXYZ")
+	Channel      = map[string]PowChannel{}
+)
 
 func init() {
 	seed = "OYSTERPRLOYSTERPRLOYSTERPRLOYSTERPRLOYSTERPRLOYSTERPRLOYSTERPRLOYSTERPRLOYSTERPRL"
@@ -65,10 +81,211 @@ func init() {
 		VerifyChunksMatchRecord:        verifyChunksMatchRecord,
 		ChunksMatch:                    chunksMatch,
 	}
+
+	PowProcs = runtime.NumCPU()
+	if PowProcs != 1 {
+		PowProcs--
+	}
+
+	//makeFakeChunks()
+
+	makeChannels(PowProcs)
+}
+
+func makeFakeChunks() {
+
+	dataMaps := []models.DataMap{}
+
+	models.BuildDataMaps("GENHASH2", 100000)
+
+	_ = models.DB.RawQuery("SELECT * from data_maps").All(&dataMaps)
+
+	for i := 0; i < len(dataMaps); i++ {
+		dataMaps[i].Address = randSeq(81)
+		dataMaps[i].Message = "TESTMESSAGE"
+		dataMaps[i].Status = models.Unassigned
+
+		models.DB.ValidateAndSave(&dataMaps[i])
+	}
+}
+
+func makeChannels(powProcs int) {
+
+	err := models.DB.RawQuery("DELETE from chunk_channels;").All(&[]models.ChunkChannel{})
+
+	if err != nil {
+		raven.CaptureError(err, nil)
+	}
+
+	for i := 0; i < powProcs; i++ {
+
+		jobQueue := make(chan PowJob)
+
+		var err error;
+		newID := randSeq(10)
+
+		channel := models.ChunkChannel{}
+		channel.ChannelID = newID
+		channel.EstReadyTime = time.Now()
+		channel.ChunksProcessed = 0
+
+		_, err = models.DB.ValidateAndSave(&channel)
+		if err != nil {
+			raven.CaptureError(err, nil)
+		}
+		models.DB.RawQuery("SELECT * from chunk_channels where channel_id = ?", newID).First(&channel)
+
+		Channel[newID] = PowChannel{
+			DBChannel: channel,
+			ChannelID: channel.ChannelID,
+			Channel:   jobQueue,
+		}
+
+		// start the worker
+		go PowWorker(Channel[newID].Channel, newID, err)
+	}
+}
+
+func randSeq(n int) string {
+	b := make([]rune, n)
+	for i := range b {
+		b[i] = letters[rand.Intn(len(letters))]
+	}
+	return string(b)
+}
+
+func PowWorker(jobQueue <-chan PowJob, channelID string, err error) {
+	for powJobRequest := range jobQueue {
+		// this is where we would call methods to deal with each job request
+		fmt.Println("PowWorker: Starting")
+
+		// do filtering/finding BEFORE chunks ever get send to these channels
+
+		transfersArray := make([]giota.Transfer, len(powJobRequest.Chunks))
+
+		tag := "OYSTERGOLANG"
+
+		for i, chunk := range powJobRequest.Chunks {
+			transfersArray[i].Address = giota.Address(chunk.Address)
+			transfersArray[i].Value = int64(0)
+			transfersArray[i].Message = giota.Trytes(chunk.Message)
+			transfersArray[i].Tag = giota.Trytes(tag)
+		}
+
+		bdl, err := giota.PrepareTransfers(api, seed, transfersArray, nil, "", 1)
+
+		if err != nil {
+			raven.CaptureError(err, nil)
+			return
+		}
+
+		transactions := []giota.Transaction(bdl)
+
+		transactionsToApprove, err := api.GetTransactionsToApprove(minDepth, giota.DefaultNumberOfWalks, "")
+		if err != nil {
+			raven.CaptureError(err, nil)
+			return
+		}
+
+		err = doPowAndBroadcast(
+			transactionsToApprove.BranchTransaction,
+			transactionsToApprove.TrunkTransaction,
+			minDepth,
+			transactions,
+			minWeightMag,
+			bestPow,
+			powJobRequest.BroadcastNodes)
+
+		fmt.Println("PowWorker: Leaving")
+	}
+}
+
+func doPowAndBroadcast(branch giota.Trytes, trunk giota.Trytes, depth int64,
+	trytes []giota.Transaction, mwm int64, bestPow giota.PowFunc, broadcastNodes []string) error {
+
+	//defer oysterUtils.TimeTrack(time.Now(), "doPow_using_" + powName, analytics.NewProperties().
+	//	Set("addresses", oysterUtils.MapTransactionsToAddrs(trytes)))
+
+	var prev giota.Trytes
+	var err error
+
+	for i := len(trytes) - 1; i >= 0; i-- {
+		switch {
+		case i == len(trytes)-1:
+			trytes[i].TrunkTransaction = trunk
+			trytes[i].BranchTransaction = branch
+		default:
+			trytes[i].TrunkTransaction = prev
+			trytes[i].BranchTransaction = trunk
+		}
+
+		timestamp := giota.Int2Trits(time.Now().UnixNano()/1000000, giota.TimestampTrinarySize).Trytes()
+		trytes[i].AttachmentTimestamp = timestamp
+		trytes[i].AttachmentTimestampLowerBound = ""
+		trytes[i].AttachmentTimestampUpperBound = maxTimestampTrytes
+
+		// We customized this to lock here.
+		mutex.Lock()
+		trytes[i].Nonce, err = bestPow(trytes[i].Trytes(), int(mwm))
+		mutex.Unlock()
+
+		if err != nil {
+			raven.CaptureError(err, nil)
+			return err
+		}
+
+		prev = trytes[i].Hash()
+	}
+
+	go func(branch giota.Trytes, trunk giota.Trytes, depth int64,
+		trytes []giota.Transaction, mwm int64, bestPow giota.PowFunc, broadcastNodes []string) {
+
+		err = api.BroadcastTransactions(trytes)
+
+		if err != nil {
+
+			// Async log
+			//go oysterUtils.SegmentClient.Enqueue(analytics.Track{
+			//	Event:  "broadcast_fail_redoing_pow",
+			//	UserId: oysterUtils.GetLocalIP(),
+			//	Properties: analytics.NewProperties().
+			//		Set("addresses", oysterUtils.MapTransactionsToAddrs(trytes)),
+			//})
+
+			raven.CaptureError(err, nil)
+		} else {
+
+			/*
+			TODO do we need this??
+			 */
+			//go BroadcastTxs(&trytes, broadcastNodes)
+
+			//go oysterUtils.SegmentClient.Enqueue(analytics.Track{
+			//	Event:  "broadcast_success",
+			//	UserId: oysterUtils.GetLocalIP(),
+			//	Properties: analytics.NewProperties().
+			//		Set("addresses", oysterUtils.MapTransactionsToAddrs(trytes)),
+			//})
+		}
+	}(branch, trunk, depth, trytes, mwm, bestPow, broadcastNodes)
+
+	return nil
 }
 
 func processChunks(chunks []models.DataMap, attachIfAlreadyAttached bool) {
-	fmt.Println(chunks)
+	channel := models.ChunkChannel{}
+
+	err := models.DB.RawQuery("SELECT * from chunk_channels WHERE est_ready_time <= ?;", time.Now()).First(&channel)
+	if err != nil {
+		raven.CaptureError(err, nil)
+	}
+
+	powJob := PowJob{
+		Chunks: chunks,
+		BroadcastNodes: make([]string, 1),
+	}
+
+	Channel[channel.ChannelID].Channel <- powJob
 }
 
 func verifyChunkMessagesMatchRecord(chunks []models.DataMap) (filteredChunks FilteredChunk, err error) {
@@ -92,7 +309,7 @@ func verifyChunksMatchRecord(chunks []models.DataMap, checkChunkAndBranch bool) 
 	response, err := api.FindTransactions(&request)
 
 	if err != nil {
-		fmt.Println(err)
+		raven.CaptureError(err, nil)
 		return filteredChunks, err
 	}
 
@@ -101,7 +318,7 @@ func verifyChunksMatchRecord(chunks []models.DataMap, checkChunkAndBranch bool) 
 	if response != nil && len(response.Hashes) > 0 {
 		trytesArray, err := api.GetTrytes(response.Hashes)
 		if err != nil {
-			fmt.Println(err)
+			raven.CaptureError(err, nil)
 			return filteredChunks, err
 		}
 


### PR DESCRIPTION
-Job runner is running jobs on the intervals specified, then requeues them to run again
-Added some more iota methods
-Detect number of cores on startup and make that many channels (minus 1)
-Pull unassigned chunks from data_maps in processUnassignedChunks task
-Assign chunks to a "ready" channel that does the PoW  

Currently there's no tracking yet of avg time per chunk, ergo no altering or resetting of "est_ready_time"  

Trying to design this in such a way that it's simple to slip in the hooknodes when we're ready to bring them back.