### PR TITLE
Process paid sessions

### DIFF
--- a/actions/upload_sessions.go
+++ b/actions/upload_sessions.go
@@ -133,7 +133,6 @@ func (usr *UploadSessionResource) Update(c buffalo.Context) error {
 			if chunk.Hash == dm.GenesisHash {
 				// Updates dmap in DB.
 				dm.Message = chunk.Data
-				dm.Status = models.Unassigned
 				models.DB.ValidateAndSave(&dm)
 			}
 

--- a/jobs/confirm_data_maps.go
+++ b/jobs/confirm_data_maps.go
@@ -1,1 +1,0 @@
-package jobs

--- a/jobs/confirm_data_maps_test.go
+++ b/jobs/confirm_data_maps_test.go
@@ -1,1 +1,0 @@
-package jobs

--- a/jobs/process_paid_sessions.go
+++ b/jobs/process_paid_sessions.go
@@ -1,0 +1,118 @@
+package jobs
+
+import (
+	"encoding/json"
+	"github.com/getsentry/raven-go"
+	"github.com/gobuffalo/pop/slices"
+	"github.com/oysterprotocol/brokernode/models"
+)
+
+func init() {
+}
+
+func ProcessPaidSessions() {
+
+	BuryTreasureInPaidDataMaps()
+	MarkBuriedMapsAsUnassigned()
+}
+
+func BuryTreasureInPaidDataMaps() {
+	unburiedSessions := []models.UploadSession{}
+
+	err := models.DB.Where("payment_status = ? AND treasure_status = ?",
+		models.PaymentStatusPaid, models.TreasureUnburied).All(&unburiedSessions)
+	if err != nil {
+		raven.CaptureError(err, nil)
+	}
+
+	treasureChunks := []models.DataMap{}
+
+	for _, unburiedSession := range unburiedSessions {
+
+		/*TODO
+		pop queries for "where in" need a slice type to work (pop/slices)
+
+		https://godoc.org/github.com/gobuffalo/pop/slices#Int
+
+		But, I cannot seem to get it to work.
+		treasureIndex is an array of ints but "where in" won't work with it, and cannot figure
+		out how to convert a regular array of ints to type pop/slices.
+
+		Even with just manually inputting some dummy ints into slices.Int{} the "where in" does not
+		seem to work.
+		*/
+
+		// this is taking the json from treasureIdxMap and making it an array of ints.
+		// tried to pass in slices.Int{} as the interface but that did not work.
+		// https://play.golang.org/p/nQorh-mMYOw
+		treasureIndex := []int{}
+		if unburiedSession.TreasureIdxMap.Valid {
+			// only do this if the string value is valid
+			err := json.Unmarshal([]byte(unburiedSession.TreasureIdxMap.String), &treasureIndex)
+			if err != nil {
+				raven.CaptureError(err, nil)
+			}
+		}
+
+		/*@TODO remove this and actually make a slices.Int object that haves the values from
+		TreasureIdxMap and get the "where in" query to work
+		*/
+		treasureSlices := slices.Int{1, 220, 355}
+
+		err = models.DB.RawQuery("SELECT * from data_maps WHERE genesis_hash = ? "+
+			"AND chunk_idx in (?) ORDER BY chunk_idx asc",
+			unburiedSession.GenesisHash,
+			treasureSlices).All(&treasureChunks)
+
+		BuryTreasure(treasureChunks, &unburiedSession)
+
+		if len(treasureChunks) != 0 {
+			unburiedSession.TreasureStatus = models.TreasureBuried
+			models.DB.ValidateAndSave(&unburiedSession)
+		}
+	}
+}
+
+func BuryTreasure(treasureChunks []models.DataMap, unburiedSession *models.UploadSession) {
+
+	var err error
+
+	/*@TODO would be better to re-write this method such that we're passing in the seeds, so we can pass in
+	@TODO dummy seeds for our unit tests.
+	*/
+
+	//@TODO grab the ethereum seeds once we have ethereum functionality enabled.  For now just using a dummy seed.
+
+	//@TODO do something in the event that the length of the seeds isn't the same as the length of the treasureChunks
+
+	/*@TODO remove this*/
+	dummyEthSeed := "1004444400000006780000000000000000000000000012345000000765430001"
+
+	for _, treasureChunk := range treasureChunks {
+		treasureChunk.Message, err = models.CreateTreasurePayload(dummyEthSeed, treasureChunk.Hash, models.MaxSideChainLength)
+		if err != nil {
+			raven.CaptureError(err, nil)
+		}
+		models.DB.ValidateAndSave(&treasureChunk)
+	}
+}
+
+// marking the maps as "Unassigned" will trigger them to get processed by the process_unassigned_chunks cron task.
+func MarkBuriedMapsAsUnassigned() {
+	readySessions := []models.UploadSession{}
+
+	err := models.DB.Where("payment_status = ? AND treasure_status = ?",
+		models.PaymentStatusPaid, models.TreasureBuried).All(&readySessions)
+	if err != nil {
+		raven.CaptureError(err, nil)
+	}
+
+	var dataMaps = []models.DataMap{}
+
+	for _, readySession := range readySessions {
+		err = models.DB.RawQuery("UPDATE data_maps SET status = ? WHERE genesis_hash = ? AND status = ?",
+			models.Unassigned,
+			readySession.GenesisHash,
+			models.Pending).All(&dataMaps)
+	}
+}

--- a/jobs/process_paid_sessions_test.go
+++ b/jobs/process_paid_sessions_test.go
@@ -1,0 +1,61 @@
+package jobs_test
+
+import (
+	"github.com/gobuffalo/pop/nulls"
+	//"github.com/oysterprotocol/brokernode/jobs"
+	//"github.com/oysterprotocol/brokernode/models"
+	"github.com/oysterprotocol/brokernode/jobs"
+	"github.com/oysterprotocol/brokernode/models"
+)
+
+func (suite *JobsSuite) Test_ProcessPaidSessions() {
+	fileBytesCount := 750000
+
+	uploadSession1 := models.UploadSession{
+		GenesisHash:    "genHash1",
+		FileSizeBytes:  fileBytesCount,
+		Type:           models.SessionTypeAlpha,
+		PaymentStatus:  models.PaymentStatusPaid,
+		TreasureStatus: models.TreasureUnburied,
+		TreasureIdxMap: nulls.String{"[1, 220, 355]", true},
+	}
+
+	uploadSession1.StartUploadSession()
+
+	uploadSession2 := models.UploadSession{
+		GenesisHash:    "genHash2",
+		FileSizeBytes:  fileBytesCount,
+		Type:           models.SessionTypeAlpha,
+		PaymentStatus:  models.PaymentStatusPaid,
+		TreasureStatus: models.TreasureBuried,
+		TreasureIdxMap: nulls.String{"[45, 278, 305]", true},
+	}
+
+	uploadSession2.StartUploadSession()
+
+	paidButUnburied := []models.DataMap{}
+	err := suite.DB.Where("genesis_hash = ?", "genHash1").All(&paidButUnburied)
+	suite.Equal(err, nil)
+
+	paidAndUnburied := []models.DataMap{}
+	err = suite.DB.Where("genesis_hash = ?", "genHash1").All(&paidAndUnburied)
+	suite.Equal(err, nil)
+
+	suite.NotEqual(0, len(paidButUnburied))
+	suite.NotEqual(0, len(paidAndUnburied))
+
+	for _, dMap := range paidButUnburied {
+		suite.Equal("", dMap.Message)
+	}
+
+	jobs.ProcessPaidSessions()
+
+	paidButUnburied = []models.DataMap{}
+	err = suite.DB.Where("genesis_hash = ?", "genHash1").All(&paidButUnburied)
+	suite.Equal(err, nil)
+
+	/*@TODO after getting the slices and "where in" queries working, verify that the chunks with the correct
+	indexes no longer have "" for their "message" fields and verify that all data map statuses have changed to
+	"Unassigned"
+	*/
+}

--- a/jobs/process_unassigned_chunks.go
+++ b/jobs/process_unassigned_chunks.go
@@ -69,7 +69,7 @@ func AssignChunksToChannels(chunks []models.DataMap, iotaWrapper services.IotaSe
 
 func GetUnassignedChunks() (dataMaps []models.DataMap, err error) {
 
-	query := models.DB.Where("status = ?", models.Unassigned)
+	query := models.DB.Where("status = ? OR status = ?", models.Unassigned, models.Error)
 	dataMaps = []models.DataMap{}
 	err = query.All(&dataMaps)
 	if err != nil {

--- a/migrations/.gitignore
+++ b/migrations/.gitignore
@@ -1,0 +1,1 @@
+/schema.sql

--- a/migrations/20180313231024_create_data_maps.up.fizz
+++ b/migrations/20180313231024_create_data_maps.up.fizz
@@ -3,6 +3,7 @@ create_table("data_maps", func(t) {
 	t.Column("genesis_hash", "string", {})
 	t.Column("chunk_idx", "integer", {})
 	t.Column("hash", "string", {})
+	t.Column("obfuscated_hash", "string", {})
 	t.Column("status", "integer", {})
 	t.Column("node_id", "string", {"null": true})
     t.Column("node_type", "string", {"null": true})

--- a/migrations/20180316183149_create_upload_sessions.up.fizz
+++ b/migrations/20180316183149_create_upload_sessions.up.fizz
@@ -10,8 +10,10 @@ create_table("upload_sessions", func(t) {
 	t.Column("eth_private_key", "string", {"null": true})
 	t.Column("total_cost", "DECIMAL(28, 18)", {})
 	t.Column("payment_status", "integer", {})
+	t.Column("treasure_status", "integer", {})
 
 	t.Column("treasure_idx_map", "JSON", {"null": true})
+
 })
 
 add_index("upload_sessions", "genesis_hash", {"unique": true})

--- a/migrations/20180320145525_create_completed_data_maps.up.fizz
+++ b/migrations/20180320145525_create_completed_data_maps.up.fizz
@@ -2,6 +2,7 @@ create_table("completed_data_maps", func(t) {
 	t.Column("genesis_hash", "string", {})
 	t.Column("chunk_idx", "integer", {})
 	t.Column("hash", "string", {})
+	t.Column("obfuscated_hash", "string", {})
 	t.Column("status", "integer", {})
 	t.Column("node_id", "string", {"null": true})
     t.Column("node_type", "string", {"null": true})

--- a/models/completed_data_maps.go
+++ b/models/completed_data_maps.go
@@ -10,19 +10,20 @@ import (
 )
 
 type CompletedDataMap struct {
-	ID          int       `json:"id" db:"id"`
-	CreatedAt   time.Time `json:"createdAt" db:"created_at"`
-	UpdatedAt   time.Time `json:"updatedAt" db:"updated_at"`
-	Status      int       `json:"status" db:"status"`
-	NodeID      string    `json:"nodeID" db:"node_id"`
-	NodeType    string    `json:"nodeType" db:"node_type"`
-	Message     string    `json:"message" db:"message"`
-	TrunkTx     string    `json:"trunkTx" db:"trunk_tx"`
-	BranchTx    string    `json:"branchTx" db:"branch_tx"`
-	GenesisHash string    `json:"genesisHash" db:"genesis_hash"`
-	ChunkIdx    int       `json:"chunkIdx" db:"chunk_idx"`
-	Hash        string    `json:"hash" db:"hash"`
-	Address     string    `json:"address" db:"address"`
+	ID             int       `json:"id" db:"id"`
+	CreatedAt      time.Time `json:"createdAt" db:"created_at"`
+	UpdatedAt      time.Time `json:"updatedAt" db:"updated_at"`
+	Status         int       `json:"status" db:"status"`
+	NodeID         string    `json:"nodeID" db:"node_id"`
+	NodeType       string    `json:"nodeType" db:"node_type"`
+	Message        string    `json:"message" db:"message"`
+	TrunkTx        string    `json:"trunkTx" db:"trunk_tx"`
+	BranchTx       string    `json:"branchTx" db:"branch_tx"`
+	GenesisHash    string    `json:"genesisHash" db:"genesis_hash"`
+	ChunkIdx       int       `json:"chunkIdx" db:"chunk_idx"`
+	Hash           string    `json:"hash" db:"hash"`
+	ObfuscatedHash string    `json:"obfuscatedHash" db:"obfuscated_hash"`
+	Address        string    `json:"address" db:"address"`
 }
 
 func init() {

--- a/models/data_maps_test.go
+++ b/models/data_maps_test.go
@@ -1,8 +1,26 @@
 package models_test
 
 import (
+	"crypto/sha512"
 	"github.com/oysterprotocol/brokernode/models"
+	"github.com/oysterprotocol/brokernode/utils"
+
+	"github.com/iotaledger/giota"
 )
+
+type hashAddressConversion struct {
+	sha256Hash     string
+	ethPrivateSeed string
+}
+
+var encryptedTreasureCases = []hashAddressConversion{
+	{sha256Hash: "64dc1ce4655554f514a4ce83e08c1d08372fdf02bd8c9b6dbecfc74b783d39d1",
+		ethPrivateSeed: "0000000000000000000000000000000000000000000000000000000000000001"},
+	{sha256Hash: "99577b266e77d07e364d0b87bf1bcef44c78e3668dfdc3881969b375c09d4fcd",
+		ethPrivateSeed: "1004444400000006780000000000000000000000000012345000000765430001"},
+	{sha256Hash: "7fb4ca9cc0032bafc2ebd0fda018a41f5adfcf441123de22ab736a42207933f7",
+		ethPrivateSeed: "7777777774444444777777744444447777777444444777777744444777777744"},
+}
 
 func (ms *ModelSuite) Test_BuildDataMaps() {
 	genHash := "genHashTest"
@@ -26,6 +44,30 @@ func (ms *ModelSuite) Test_BuildDataMaps() {
 	ms.DB.Where("genesis_hash = ?", genHash).Order("chunk_idx asc").All(&dMaps)
 
 	for i, dMap := range dMaps {
-		ms.Equal(expectedHashes[i], dMap.Hash)
+		ms.Equal(expectedHashes[i], dMap.ObfuscatedHash)
 	}
+}
+
+func (ms *ModelSuite) Test_CreateTreasurePayload() {
+	maxSideChainLength := 50
+	matchesFound := 0
+
+	for _, tc := range encryptedTreasureCases {
+		payload, err := models.CreateTreasurePayload(tc.ethPrivateSeed, tc.sha256Hash, maxSideChainLength)
+		ms.Nil(err)
+
+		payloadNotTryted := oyster_utils.TrytesToBytes(giota.Trytes(payload))
+
+		currentHash := tc.sha256Hash
+
+		for i := 0; i < maxSideChainLength; i++ {
+			currentHash = oyster_utils.HashString(currentHash, sha512.New())
+			result := oyster_utils.Decrypt(currentHash, string(payloadNotTryted))
+			if result != "" {
+				ms.Equal(result, tc.ethPrivateSeed)
+				matchesFound++
+			}
+		}
+	}
+	ms.Equal(3, matchesFound)
 }

--- a/models/upload_sessions.go
+++ b/models/upload_sessions.go
@@ -36,8 +36,9 @@ type UploadSession struct {
 	ETHAddrBeta   nulls.String `json:"ethAddrBeta" db:"eth_addr_beta"`
 	ETHPrivateKey nulls.String `db:"eth_private_key"`
 	// TODO: Floats shouldn't be used for prices, use https://github.com/shopspring/decimal.
-	TotalCost     float64 `json:"totalCost" db:"total_cost"`
-	PaymentStatus int     `json:"paymentStatus" db:"payment_status"`
+	TotalCost      float64 `json:"totalCost" db:"total_cost"`
+	PaymentStatus  int     `json:"paymentStatus" db:"payment_status"`
+	TreasureStatus int     `json:"treasureStatus" db:"treasure_status"`
 
 	TreasureIdxMap nulls.String `json:"treasureIdxMap" db:"treasure_idx_map"`
 }
@@ -46,6 +47,11 @@ const (
 	PaymentStatusPending int = iota + 1
 	PaymentStatusPaid
 	PaymentStatusError = -1
+)
+
+const (
+	TreasureUnburied int = iota + 1
+	TreasureBuried
 )
 
 // String is not required by pop and may be deleted
@@ -101,6 +107,11 @@ func (u *UploadSession) BeforeCreate(tx *pop.Connection) error {
 	// Defaults to paymentStatusPending
 	if u.PaymentStatus == 0 {
 		u.PaymentStatus = PaymentStatusPending
+	}
+
+	// Defaults to treasureUnburied
+	if u.TreasureStatus == 0 {
+		u.TreasureStatus = TreasureUnburied
 	}
 
 	return nil

--- a/models/upload_sessions_test.go
+++ b/models/upload_sessions_test.go
@@ -56,6 +56,6 @@ func (ms *ModelSuite) Test_DataMapsForSession() {
 	ms.Nil(err)
 
 	for i, dMap := range *dMaps {
-		ms.Equal(expectedHashes[i], dMap.Hash)
+		ms.Equal(expectedHashes[i], dMap.ObfuscatedHash)
 	}
 }

--- a/services/iota_wrappers.go
+++ b/services/iota_wrappers.go
@@ -344,7 +344,15 @@ func verifyChunksMatchRecord(chunks []models.DataMap, checkChunkAndBranch bool) 
 	addresses := make([]giota.Address, 0, len(chunks))
 
 	for _, chunk := range chunks {
-		addresses = append(addresses, giota.Address(chunk.Address))
+		// if a chunk did not match the tangle in verify_data_maps
+		// we mark it as "Error" and there is no reason to check the tangle
+		// for it again while its status is still in an Error state
+
+		// this will cause this chunk to automatically get added to 'NotAttached' array
+		// and send to the channels
+		if chunk.Status != models.Error {
+			addresses = append(addresses, giota.Address(chunk.Address))
+		}
 	}
 
 	request := giota.FindTransactionsRequest{

--- a/utils/cryptography.go
+++ b/utils/cryptography.go
@@ -1,0 +1,53 @@
+package oyster_utils
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
+	"hash"
+	"strings"
+
+	"golang.org/x/crypto/pbkdf2"
+)
+
+func deriveKey(passphrase string, salt []byte) ([]byte, []byte) {
+	if salt == nil {
+		salt = make([]byte, 8)
+		// http://www.ietf.org/rfc/rfc2898.txt
+		// Salt.
+		rand.Read(salt)
+	}
+	return pbkdf2.Key([]byte(passphrase), salt, 1000, 32, sha256.New), salt
+}
+
+func Encrypt(passphrase, plaintext string) string {
+	key, salt := deriveKey(passphrase, nil)
+	iv := make([]byte, 12)
+	// http://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication800-38d.pdf
+	// Section 8.2
+	rand.Read(iv)
+	b, _ := aes.NewCipher(key)
+	aesgcm, _ := cipher.NewGCM(b)
+	data := aesgcm.Seal(nil, iv, []byte(plaintext), nil)
+	return hex.EncodeToString(salt) + "-" + hex.EncodeToString(iv) + "-" + hex.EncodeToString(data)
+}
+
+func Decrypt(passphrase, ciphertext string) string {
+	arr := strings.Split(ciphertext, "-")
+	salt, _ := hex.DecodeString(arr[0])
+	iv, _ := hex.DecodeString(arr[1])
+	data, _ := hex.DecodeString(arr[2])
+	key, _ := deriveKey(passphrase, salt)
+	b, _ := aes.NewCipher(key)
+	aesgcm, _ := cipher.NewGCM(b)
+	data, _ = aesgcm.Open(nil, iv, data, nil)
+	return string(data)
+}
+
+func HashString(str string, shaAlg hash.Hash) (h string) {
+	shaAlg.Write([]byte(str))
+	h = hex.EncodeToString(shaAlg.Sum(nil))
+	return
+}

--- a/utils/cryptography_test.go
+++ b/utils/cryptography_test.go
@@ -1,0 +1,1 @@
+package oyster_utils


### PR DESCRIPTION
This PR adds the following:
-a cron job to process paid sessions.  This task makes the PRL payloads in the "message" field and marks all data maps as 'unassigned' if they have paid and their PRLs are buried, which means the process_unassigned_data_maps task will pick them up for processing
-there was a potentially issue with data maps that didn't match the tangle as of verify_data_maps being reassigned a status of "Unassigned", whereupon the process_unassigned_datamaps would promptly do the verification again.  So instead making use of the "Error" status for data maps that don't make the tangle, so when we come across such a status, we won't attempt to (re)verify that it matches the tangle.  We'll just automatically process it and mark it as "Unverified" whereupon it will eventually get picked up by verify_data_maps again.  
-adds a TreasureStatus to upload sessions
-don't automatically mark data_maps as "Unassigned" unless we're actually ready to process them (i.e. they paid and their treasure is buried)
-no longer send chunks to channels in verify_data_maps.  Simply verify they do (or don't) match and set status accordingly.  Process_unassigned will pick up all the ones with a status of Unassigned or Error.
-could have swore I already did a PR to create the treasure payloads and add some cryptography files but maybe not, since they are showing up in this one.  