### PR TITLE
Process paid sessions 2

### DIFF
--- a/jobs/process_paid_sessions.go
+++ b/jobs/process_paid_sessions.go
@@ -2,10 +2,17 @@ package jobs
 
 import (
 	"encoding/json"
+	"errors"
 	"github.com/getsentry/raven-go"
-	"github.com/gobuffalo/pop/slices"
 	"github.com/oysterprotocol/brokernode/models"
+	"log"
 )
+
+type TreasureMap struct {
+	Sector int    `json:"sector"`
+	Idx    int    `json:"idx"`
+	Key    string `json:"key"`
+}
 
 func init() {
 }
@@ -17,6 +24,7 @@ func ProcessPaidSessions() {
 }
 
 func BuryTreasureInPaidDataMaps() {
+
 	unburiedSessions := []models.UploadSession{}
 
 	err := models.DB.Where("payment_status = ? AND treasure_status = ?",
@@ -25,27 +33,9 @@ func BuryTreasureInPaidDataMaps() {
 		raven.CaptureError(err, nil)
 	}
 
-	treasureChunks := []models.DataMap{}
-
 	for _, unburiedSession := range unburiedSessions {
 
-		/*TODO
-		pop queries for "where in" need a slice type to work (pop/slices)
-
-		https://godoc.org/github.com/gobuffalo/pop/slices#Int
-
-		But, I cannot seem to get it to work.
-		treasureIndex is an array of ints but "where in" won't work with it, and cannot figure
-		out how to convert a regular array of ints to type pop/slices.
-
-		Even with just manually inputting some dummy ints into slices.Int{} the "where in" does not
-		seem to work.
-		*/
-
-		// this is taking the json from treasureIdxMap and making it an array of ints.
-		// tried to pass in slices.Int{} as the interface but that did not work.
-		// https://play.golang.org/p/nQorh-mMYOw
-		treasureIndex := []int{}
+		treasureIndex := []TreasureMap{}
 		if unburiedSession.TreasureIdxMap.Valid {
 			// only do this if the string value is valid
 			err := json.Unmarshal([]byte(unburiedSession.TreasureIdxMap.String), &treasureIndex)
@@ -54,47 +44,38 @@ func BuryTreasureInPaidDataMaps() {
 			}
 		}
 
-		/*@TODO remove this and actually make a slices.Int object that haves the values from
-		TreasureIdxMap and get the "where in" query to work
-		*/
-		treasureSlices := slices.Int{1, 220, 355}
-
-		err = models.DB.RawQuery("SELECT * from data_maps WHERE genesis_hash = ? "+
-			"AND chunk_idx in (?) ORDER BY chunk_idx asc",
-			unburiedSession.GenesisHash,
-			treasureSlices).All(&treasureChunks)
-
-		BuryTreasure(treasureChunks, &unburiedSession)
-
-		if len(treasureChunks) != 0 {
-			unburiedSession.TreasureStatus = models.TreasureBuried
-			models.DB.ValidateAndSave(&unburiedSession)
-		}
+		BuryTreasure(treasureIndex, &unburiedSession)
 	}
 }
 
-func BuryTreasure(treasureChunks []models.DataMap, unburiedSession *models.UploadSession) {
+func BuryTreasure(treasureIndexMap []TreasureMap, unburiedSession *models.UploadSession) error {
 
-	var err error
-
-	/*@TODO would be better to re-write this method such that we're passing in the seeds, so we can pass in
-	@TODO dummy seeds for our unit tests.
-	*/
-
-	//@TODO grab the ethereum seeds once we have ethereum functionality enabled.  For now just using a dummy seed.
-
-	//@TODO do something in the event that the length of the seeds isn't the same as the length of the treasureChunks
-
-	/*@TODO remove this*/
-	dummyEthSeed := "1004444400000006780000000000000000000000000012345000000765430001"
-
-	for _, treasureChunk := range treasureChunks {
-		treasureChunk.Message, err = models.CreateTreasurePayload(dummyEthSeed, treasureChunk.Hash, models.MaxSideChainLength)
+	for _, entry := range treasureIndexMap {
+		treasureChunks := []models.DataMap{}
+		err := models.DB.Where("genesis_hash = ?",
+			unburiedSession.GenesisHash).Where("chunk_idx = ?", entry.Idx).All(&treasureChunks)
 		if err != nil {
 			raven.CaptureError(err, nil)
+			return err
 		}
-		models.DB.ValidateAndSave(&treasureChunk)
+		if len(treasureChunks) == 0 || len(treasureChunks) > 1 {
+			errString := "did not find a chunk that matched genesis_hash and chunk_idx in process_paid_sessions, or " +
+				"found duplicate chunks"
+			log.Println(errString)
+			err = errors.New(errString)
+			raven.CaptureError(err, nil)
+			return err
+		}
+		treasureChunks[0].Message, err = models.CreateTreasurePayload(entry.Key, treasureChunks[0].Hash, models.MaxSideChainLength)
+		if err != nil {
+			raven.CaptureError(err, nil)
+			return err
+		}
+		models.DB.ValidateAndSave(&treasureChunks[0])
 	}
+	unburiedSession.TreasureStatus = models.TreasureBuried
+	models.DB.ValidateAndSave(unburiedSession)
+	return nil
 }
 
 // marking the maps as "Unassigned" will trigger them to get processed by the process_unassigned_chunks cron task.

--- a/jobs/process_paid_sessions_test.go
+++ b/jobs/process_paid_sessions_test.go
@@ -1,6 +1,7 @@
 package jobs_test
 
 import (
+	"encoding/json"
 	"fmt"
 	"github.com/gobuffalo/pop/nulls"
 	"github.com/oysterprotocol/brokernode/jobs"
@@ -126,5 +127,25 @@ func (suite *JobsSuite) Test_ProcessPaidSessions() {
 	// verify that all chunks in paidAndBuried have statuses changed to Unassigned
 	for _, dMap := range paidAndBuried {
 		suite.Equal(models.Unassigned, dMap.Status)
+	}
+
+	// get the session that was originally paid but unburied, and verify that all the
+	// keys are now "" but that we still have a value for the Idx
+	paidAndUnburiedSession := models.UploadSession{}
+	err = suite.DB.Where("genesis_hash = ?", "genHash1").First(&paidAndUnburiedSession)
+	suite.Equal(err, nil)
+
+	treasureIndex := []jobs.TreasureMap{}
+	if paidAndUnburiedSession.TreasureIdxMap.Valid {
+		err := json.Unmarshal([]byte(paidAndUnburiedSession.TreasureIdxMap.String), &treasureIndex)
+		suite.Equal(err, nil)
+	}
+
+	suite.Equal(3, len(treasureIndex))
+
+	for _, entry := range treasureIndex {
+		suite.Equal("", entry.Key)
+		_, ok := treasureIndexes[entry.Idx]
+		suite.Equal(true, ok)
 	}
 }

--- a/jobs/process_paid_sessions_test.go
+++ b/jobs/process_paid_sessions_test.go
@@ -1,61 +1,130 @@
 package jobs_test
 
 import (
+	"fmt"
 	"github.com/gobuffalo/pop/nulls"
-	//"github.com/oysterprotocol/brokernode/jobs"
-	//"github.com/oysterprotocol/brokernode/models"
 	"github.com/oysterprotocol/brokernode/jobs"
 	"github.com/oysterprotocol/brokernode/models"
 )
 
 func (suite *JobsSuite) Test_ProcessPaidSessions() {
-	fileBytesCount := 750000
+	fileBytesCount := 500000
 
+	// This map seems pointless but it makes the testing
+	// in the for loop later on a bit simpler
+	treasureIndexes := map[int]int{}
+	treasureIndexes[5] = 5
+	treasureIndexes[78] = 78
+	treasureIndexes[199] = 199
+
+	// create a dummy TreasureIdxMap for the data maps
+	// that need to get treasure buried
+	testMap1 := `[{
+		"sector": 1,
+		"idx": ` + fmt.Sprint(treasureIndexes[5]) + `,
+		"key": "firstKeyFirstMap"
+		},
+		{ 
+		"sector": 2,
+		"idx": ` + fmt.Sprint(treasureIndexes[78]) + `,
+		"key": "secondKeyFirstMap"
+		},
+		{
+		"sector": 3,
+		"idx": ` + fmt.Sprint(treasureIndexes[199]) + `,
+		"key": "thirdKeyFirstMap"
+		}]`
+
+	// create another dummy TreasureIdxMap for the data maps
+	// who already have treasure buried
+	testMap2 := `[{
+		"sector": 1,
+		"idx": 155,
+		"key": "firstKeySecondMap"
+		},
+		{ 
+		"sector": 2,
+		"idx": 204,
+		"key": "secondKeySecondMap"
+		},
+		{
+		"sector": 3,
+		"idx": 599,
+		"key": "thirdKeySecondMap"
+		}]`
+
+	// create and start the upload session for the data maps that need treasure buried
 	uploadSession1 := models.UploadSession{
 		GenesisHash:    "genHash1",
 		FileSizeBytes:  fileBytesCount,
 		Type:           models.SessionTypeAlpha,
 		PaymentStatus:  models.PaymentStatusPaid,
 		TreasureStatus: models.TreasureUnburied,
-		TreasureIdxMap: nulls.String{"[1, 220, 355]", true},
+		TreasureIdxMap: nulls.String{string(testMap1), true},
 	}
 
 	uploadSession1.StartUploadSession()
 
+	// create and start the upload session for the data maps that already have buried treasure
 	uploadSession2 := models.UploadSession{
 		GenesisHash:    "genHash2",
 		FileSizeBytes:  fileBytesCount,
 		Type:           models.SessionTypeAlpha,
 		PaymentStatus:  models.PaymentStatusPaid,
 		TreasureStatus: models.TreasureBuried,
-		TreasureIdxMap: nulls.String{"[45, 278, 305]", true},
+		TreasureIdxMap: nulls.String{string(testMap2), true},
 	}
 
 	uploadSession2.StartUploadSession()
 
+	// verify that we have successfully created all the data maps
 	paidButUnburied := []models.DataMap{}
 	err := suite.DB.Where("genesis_hash = ?", "genHash1").All(&paidButUnburied)
 	suite.Equal(err, nil)
 
-	paidAndUnburied := []models.DataMap{}
-	err = suite.DB.Where("genesis_hash = ?", "genHash1").All(&paidAndUnburied)
+	paidAndBuried := []models.DataMap{}
+	err = suite.DB.Where("genesis_hash = ?", "genHash2").All(&paidAndBuried)
 	suite.Equal(err, nil)
 
 	suite.NotEqual(0, len(paidButUnburied))
-	suite.NotEqual(0, len(paidAndUnburied))
+	suite.NotEqual(0, len(paidAndBuried))
 
+	// verify that the "Message" field for every chunk in paidButUnburied is ""
 	for _, dMap := range paidButUnburied {
 		suite.Equal("", dMap.Message)
 	}
 
+	// verify that the "Status" field for every chunk in paidAndBuried is NOT Unassigned
+	for _, dMap := range paidAndBuried {
+		suite.NotEqual(models.Unassigned, dMap.Status)
+	}
+
+	// call method under test
 	jobs.ProcessPaidSessions()
 
 	paidButUnburied = []models.DataMap{}
 	err = suite.DB.Where("genesis_hash = ?", "genHash1").All(&paidButUnburied)
 	suite.Equal(err, nil)
 
-	/*@TODO after getting the slices and "where in" queries working, verify that the chunks with the correct
-	indexes no longer have "" for their "message" fields and verify that all data map statuses have changed to
-	"Unassigned"
+	/* Verify the following:
+	1.  If a chunk in paidButUnburied was one of the treasure chunks, Message is no longer ""
+	2.  Status of all data maps in paidButUnburied is now Unassigned (to get picked up by process_unassigned_chunks
 	*/
+	for _, dMap := range paidButUnburied {
+		if _, ok := treasureIndexes[dMap.ChunkIdx]; ok {
+			suite.NotEqual("", dMap.Message)
+		} else {
+			suite.Equal("", dMap.Message)
+		}
+		suite.Equal(models.Unassigned, dMap.Status)
+	}
+
+	paidAndBuried = []models.DataMap{}
+	err = suite.DB.Where("genesis_hash = ?", "genHash2").All(&paidAndBuried)
+	suite.Equal(err, nil)
+
+	// verify that all chunks in paidAndBuried have statuses changed to Unassigned
+	for _, dMap := range paidAndBuried {
+		suite.Equal(models.Unassigned, dMap.Status)
+	}
 }


### PR DESCRIPTION
-Expects a TreasureIdxMap that looks like this:
`[{
		"sector": 1,
		"idx": 155,
		"key": "firstKeySecondMap"
		},
		{ 
		"sector": 2,
		"idx": 204,
		"key": "secondKeySecondMap"
		},
		{
		"sector": 3,
		"idx": 599,
		"key": "thirdKeySecondMap"
		}]`
-Checks for sessions which have been paid but in which treasure has not been buried, and buries the treasure
-Checks for sessions which have been paid and have treasure buried and marks them as Unassigned so that process_unassigned_chunks will pick them up
-Deletes keys when we are done with them
-Unit tests for all of the above


Wound up writing the method in a way that didn't rely on "Where In" working correctly, wish I'd done that from the start.