### PR TITLE
Added get response for upload_sessions and tests

### DIFF
--- a/actions/app.go
+++ b/actions/app.go
@@ -68,6 +68,7 @@ func App() *buffalo.App {
 		apiV2.POST("upload-sessions", uploadSessionResource.Create)
 		apiV2.PUT("upload-sessions/{id}", uploadSessionResource.Update)
 		apiV2.POST("upload-sessions/beta", uploadSessionResource.CreateBeta)
+		apiV2.GET("upload-sessions/{id}", uploadSessionResource.GetPaymentStatus)
 
 		// Webnodes
 		webnodeResource := WebnodeResource{}

--- a/actions/upload_sessions.go
+++ b/actions/upload_sessions.go
@@ -54,6 +54,11 @@ type UploadSessionUpdateReq struct {
 	Chunks []chunkReq `json:"chunks"`
 }
 
+type paymentStatusCreateRes struct {
+	ID            string               `json:"id"`
+	PaymentStatus string			   `json:"paymentStatus"`
+}
+
 // Create creates an upload session.
 func (usr *UploadSessionResource) Create(c buffalo.Context) error {
 	req := uploadSessionCreateReq{}
@@ -213,5 +218,33 @@ func (usr *UploadSessionResource) CreateBeta(c buffalo.Context) error {
 		Invoice:             u.GetInvoice(),
 		BetaTreasureIndexes: betaTreasureIndexes,
 	}
+	return c.Render(200, r.JSON(res))
+}
+
+
+func (usr *UploadSessionResource) GetPaymentStatus(c buffalo.Context) error {
+	session := models.UploadSession{}
+	err := models.DB.Where("id = ?", c.Param("id")).First(&session)
+
+	if err != nil {
+		//TODO: Return better error response when ID does not exist
+		return err
+	}
+
+	paymentStatus := ""
+
+	if session.PaymentStatus == models.PaymentStatusPending {
+		paymentStatus = "pending"
+	} else if session.PaymentStatus == models.PaymentStatusPaid {
+		paymentStatus = "paid"
+	} else {
+		paymentStatus = "error"
+	}
+
+	res := paymentStatusCreateRes{
+		ID:                  session.ID.String(),
+		PaymentStatus:		 paymentStatus,
+	}
+
 	return c.Render(200, r.JSON(res))
 }

--- a/actions/upload_sessions.go
+++ b/actions/upload_sessions.go
@@ -226,7 +226,7 @@ func (usr *UploadSessionResource) GetPaymentStatus(c buffalo.Context) error {
 	session := models.UploadSession{}
 	err := models.DB.Find(&session, c.Param("id"))
 
-	if err != nil || session.ID == models.EmptyUUID {
+	if (err != nil || session == models.UploadSession{}) {
 		//TODO: Return better error response when ID does not exist
 		return err
 	}

--- a/actions/upload_sessions.go
+++ b/actions/upload_sessions.go
@@ -55,8 +55,8 @@ type UploadSessionUpdateReq struct {
 }
 
 type paymentStatusCreateRes struct {
-	ID            string               `json:"id"`
-	PaymentStatus string			   `json:"paymentStatus"`
+	ID            string `json:"id"`
+	PaymentStatus string `json:"paymentStatus"`
 }
 
 // Create creates an upload session.
@@ -221,7 +221,6 @@ func (usr *UploadSessionResource) CreateBeta(c buffalo.Context) error {
 	return c.Render(200, r.JSON(res))
 }
 
-
 func (usr *UploadSessionResource) GetPaymentStatus(c buffalo.Context) error {
 	session := models.UploadSession{}
 	err := models.DB.Find(&session, c.Param("id"))
@@ -232,8 +231,8 @@ func (usr *UploadSessionResource) GetPaymentStatus(c buffalo.Context) error {
 	}
 
 	res := paymentStatusCreateRes{
-		ID:                  session.ID.String(),
-		PaymentStatus:		 session.GetPaymentStatus(),
+		ID:            session.ID.String(),
+		PaymentStatus: session.GetPaymentStatus(),
 	}
 
 	return c.Render(200, r.JSON(res))

--- a/actions/upload_sessions.go
+++ b/actions/upload_sessions.go
@@ -224,26 +224,16 @@ func (usr *UploadSessionResource) CreateBeta(c buffalo.Context) error {
 
 func (usr *UploadSessionResource) GetPaymentStatus(c buffalo.Context) error {
 	session := models.UploadSession{}
-	err := models.DB.Where("id = ?", c.Param("id")).First(&session)
+	err := models.DB.Find(&session, c.Param("id"))
 
-	if err != nil {
+	if err != nil || session.ID == models.EmptyUUID {
 		//TODO: Return better error response when ID does not exist
 		return err
 	}
 
-	paymentStatus := ""
-
-	if session.PaymentStatus == models.PaymentStatusPending {
-		paymentStatus = "pending"
-	} else if session.PaymentStatus == models.PaymentStatusPaid {
-		paymentStatus = "paid"
-	} else {
-		paymentStatus = "error"
-	}
-
 	res := paymentStatusCreateRes{
 		ID:                  session.ID.String(),
-		PaymentStatus:		 paymentStatus,
+		PaymentStatus:		 session.GetPaymentStatus(),
 	}
 
 	return c.Render(200, r.JSON(res))

--- a/models/models.go
+++ b/models/models.go
@@ -5,16 +5,19 @@ import (
 
 	"github.com/gobuffalo/envy"
 	"github.com/gobuffalo/pop"
+	"github.com/gobuffalo/uuid"
 )
 
 // DB is a connection to your database to be used
 // throughout your application.
 var DB *pop.Connection
+var EmptyUUID uuid.UUID
 
 func init() {
 	var err error
 	env := envy.Get("GO_ENV", "development")
 	DB, err = pop.Connect(env)
+	EmptyUUID, _ = uuid.FromString("00000000-0000-0000-0000-000000000000")
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/models/models.go
+++ b/models/models.go
@@ -5,19 +5,16 @@ import (
 
 	"github.com/gobuffalo/envy"
 	"github.com/gobuffalo/pop"
-	"github.com/gobuffalo/uuid"
 )
 
 // DB is a connection to your database to be used
 // throughout your application.
 var DB *pop.Connection
-var EmptyUUID uuid.UUID
 
 func init() {
 	var err error
 	env := envy.Get("GO_ENV", "development")
 	DB, err = pop.Connect(env)
-	EmptyUUID, _ = uuid.FromString("00000000-0000-0000-0000-000000000000")
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/models/upload_sessions.go
+++ b/models/upload_sessions.go
@@ -211,3 +211,11 @@ func (u *UploadSession) SetTreasureMap(treasureIndexMap []TreasureMap) error {
 func getStoragePeg() int {
 	return 1 // TODO: write code to query smart contract to get real storage peg
 }
+
+func (u *UploadSession) GetPaymentStatus() string {
+	switch u.PaymentStatus {
+		case PaymentStatusPending: return "pending"
+		case PaymentStatusPaid: return "paid"
+		default: return "error"
+	}
+}


### PR DESCRIPTION
Currently, when the ID does not exist we return the error straight from the database. I was having trouble wiring up a custom, more user friendly, error. @rfornea could probably elaborate better than I could on this.