### PR TITLE
Processing priority

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ brokernode
 data/
 migrations/schema.sql
 .env
+*.env

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ before_script:
   #     done;
   #   "
 
-script: docker-compose exec app buffalo test -v
+script: docker-compose exec app buffalo test
 
 notifications:
   slack:

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ before_script:
   #     done;
   #   "
 
-script: docker-compose exec app buffalo test
+script: docker-compose exec app buffalo test -v
 
 notifications:
   slack:

--- a/jobs/job_runner.go
+++ b/jobs/job_runner.go
@@ -56,7 +56,7 @@ func doWork(oysterWorker *worker.Simple) {
 		Queue:   "default",
 		Handler: "verifyDataMapsHandler",
 		Args: worker.Args{
-			"duration": 60 * time.Second,
+			"duration": 30 * time.Second,
 		},
 	}
 
@@ -64,7 +64,7 @@ func doWork(oysterWorker *worker.Simple) {
 		Queue:   "default",
 		Handler: "updateTimedOutDataMapsHandler",
 		Args: worker.Args{
-			"duration": 30 * time.Second,
+			"duration": 60 * time.Second,
 		},
 	}
 

--- a/jobs/job_runner_test.go
+++ b/jobs/job_runner_test.go
@@ -15,8 +15,6 @@ type JobsSuite struct {
 }
 
 var Suite JobsSuite
-var sendChunksToChannelMockCalled = false
-var verifyChunkMessagesMatchesRecordMockCalled = false
 
 func (suite *JobsSuite) SetupSuite() {
 

--- a/jobs/process_unassigned_chunks.go
+++ b/jobs/process_unassigned_chunks.go
@@ -54,7 +54,7 @@ func AssignChunksToChannels(chunks []models.DataMap, channels []models.ChunkChan
 			break
 		}
 
-		filteredChunks, err := IotaWrapper.VerifyChunkMessagesMatchRecord(chunks[i:end])
+		filteredChunks, err := iotaWrapper.VerifyChunkMessagesMatchRecord(chunks[i:end])
 
 		if err != nil {
 			raven.CaptureError(err, nil)

--- a/jobs/process_unassigned_chunks_test.go
+++ b/jobs/process_unassigned_chunks_test.go
@@ -3,42 +3,131 @@ package jobs_test
 import (
 	"github.com/oysterprotocol/brokernode/jobs"
 	"github.com/oysterprotocol/brokernode/models"
+	"github.com/oysterprotocol/brokernode/services"
+	"time"
+)
+
+var (
+	sendChunksToChannelMockCalled = false
+	AllChunksCalled               []models.DataMap
 )
 
 func (suite *JobsSuite) Test_ProcessUnassignedChunks() {
-	genHash := "genHashTest"
-	fileBytesCount := 8500
 
-	vErr, err := models.BuildDataMaps(genHash, fileBytesCount)
-	suite.Nil(err)
-	suite.Equal(0, len(vErr.Errors))
+	// reset back to generic mocks
+	defer suite.SetupSuite()
 
-	dataMaps := []models.DataMap{}
-	suite.DB.All(&dataMaps)
+	// make suite available inside mock methods
+	Suite = *suite
 
-	unassignedTimedOut := models.DataMap{}
-	unassignedTimedOut = dataMaps[0]
-	unassignedTimedOut.Status = models.Unassigned
-	unassignedTimedOut.Message = "unassignedTimedOut"
-	suite.DB.ValidateAndSave(&unassignedTimedOut)
+	// assign the mock methods for this test
+	makeMocks_process_unassigned_chunks(&IotaMock)
 
-	unassignedNotTimedOut := models.DataMap{}
-	unassignedNotTimedOut = dataMaps[1]
-	unassignedNotTimedOut.Status = models.Unassigned
-	unassignedNotTimedOut.Message = "unassignedNotTimedOut"
-	suite.DB.ValidateAndSave(&unassignedNotTimedOut)
+	// make 3 channels
+	models.MakeChannels(3)
 
-	assignedTimedOut := models.DataMap{}
-	assignedTimedOut = dataMaps[2]
-	assignedTimedOut.Status = models.Pending
-	assignedTimedOut.Message = "assignedTimedOut"
-	suite.DB.ValidateAndSave(&assignedTimedOut)
-
-	result, err := jobs.GetUnassignedChunks()
-
-	suite.Equal(2, len(result))
-
-	for _, dMap := range result {
-		suite.Equal(models.Unassigned, dMap.Status)
+	uploadSession1 := models.UploadSession{
+		GenesisHash:    "genHash1",
+		FileSizeBytes:  3000,
+		Type:           models.SessionTypeAlpha,
+		PaymentStatus:  models.PaymentStatusPaid,
+		TreasureStatus: models.TreasureBuried,
 	}
+
+	uploadSession2 := models.UploadSession{
+		GenesisHash:    "genHash2",
+		FileSizeBytes:  3000,
+		Type:           models.SessionTypeBeta,
+		PaymentStatus:  models.PaymentStatusPaid,
+		TreasureStatus: models.TreasureBuried,
+	}
+
+	uploadSession3 := models.UploadSession{
+		GenesisHash:    "genHash3",
+		FileSizeBytes:  25000,
+		Type:           models.SessionTypeAlpha,
+		PaymentStatus:  models.PaymentStatusPaid,
+		TreasureStatus: models.TreasureBuried,
+	}
+
+	uploadSession4 := models.UploadSession{
+		GenesisHash:    "genHash4",
+		FileSizeBytes:  20000,
+		Type:           models.SessionTypeBeta,
+		PaymentStatus:  models.PaymentStatusPaid,
+		TreasureStatus: models.TreasureBuried,
+	}
+
+	uploadSession1.StartUploadSession()
+	uploadSession2.StartUploadSession()
+	uploadSession3.StartUploadSession()
+	uploadSession4.StartUploadSession()
+
+	// set uploadSession4 to be the oldest
+	err := suite.DB.RawQuery("UPDATE upload_sessions SET created_at = ? WHERE genesis_hash = ?",
+		time.Now().Add(-20*time.Second), "genHash4").All(&[]models.UploadSession{})
+	suite.Nil(err)
+
+	// set uploadSession2 to next oldest
+	err = suite.DB.RawQuery("UPDATE upload_sessions SET created_at = ? WHERE genesis_hash = ?",
+		time.Now().Add(-15*time.Second), "genHash2").All(&[]models.UploadSession{})
+	suite.Nil(err)
+
+	// set uploadSession1 to next oldest after uploadSession2
+	err = suite.DB.RawQuery("UPDATE upload_sessions SET created_at = ? WHERE genesis_hash = ?",
+		time.Now().Add(-10*time.Second), "genHash1").All(&[]models.UploadSession{})
+	suite.Nil(err)
+
+	// uploadSession3 will be the newest
+
+	// set all data maps to unassigned
+	err = suite.DB.RawQuery("UPDATE data_maps SET status = ?", models.Unassigned).All(&[]models.DataMap{})
+	suite.Nil(err)
+
+	// call method under test
+	jobs.ProcessUnassignedChunks(IotaMock)
+
+	suite.Equal(true, sendChunksToChannelMockCalled)
+	suite.Equal(30, len(AllChunksCalled))
+
+	/* This test is verifying that the chunks belonging to particular sessions were sent
+	in the order we would expect and that the ordering of chunk ids within each data map was
+	appropriate for alpha or beta.
+
+		Session 4 was the oldest session and was of type beta
+		Session 2 was next oldest and was of type beta
+		Session 1 was next-to-last oldest and was of type alpha
+		Session 3 was newest and was of type alpha
+
+
+	If BundleSize is changed, these tests will need to be changed.
+	*/
+	for i, chunk := range AllChunksCalled {
+		if i >= 0 && i < 10 {
+			suite.Equal("genHash4", chunk.GenesisHash)
+			suite.Equal(true, AllChunksCalled[i].ChunkIdx > AllChunksCalled[i+1].ChunkIdx)
+		} else if i > 10 && i < 13 {
+			suite.Equal("genHash2", chunk.GenesisHash)
+			suite.Equal(true, AllChunksCalled[i].ChunkIdx > AllChunksCalled[i+1].ChunkIdx)
+		} else if i > 13 && i < 16 {
+			suite.Equal("genHash1", chunk.GenesisHash)
+			suite.Equal(true, AllChunksCalled[i].ChunkIdx < AllChunksCalled[i+1].ChunkIdx)
+		} else if i > 16 && i < 29 {
+			suite.Equal("genHash3", chunk.GenesisHash)
+			suite.Equal(true, AllChunksCalled[i].ChunkIdx < AllChunksCalled[i+1].ChunkIdx)
+		}
+	}
+}
+
+func makeMocks_process_unassigned_chunks(iotaMock *services.IotaService) {
+	iotaMock.SendChunksToChannel = sendChunksToChannelMock_process_unassigned_chunks
+}
+
+func sendChunksToChannelMock_process_unassigned_chunks(chunks []models.DataMap, channel *models.ChunkChannel) {
+
+	// our mock was called
+	sendChunksToChannelMockCalled = true
+
+	// stored all the chunks that get sent to the mock so we can run tests on them.
+	AllChunksCalled = append(AllChunksCalled, chunks...)
 }

--- a/jobs/process_unassigned_chunks_test.go
+++ b/jobs/process_unassigned_chunks_test.go
@@ -8,8 +8,9 @@ import (
 )
 
 var (
-	sendChunksToChannelMockCalled = false
-	AllChunksCalled               []models.DataMap
+	sendChunksToChannelMockCalled_process_unassigned_chunks              = false
+	verifyChunkMessagesMatchesRecordMockCalled_process_unassigned_chunks = false
+	AllChunksCalled                                                      []models.DataMap
 )
 
 func (suite *JobsSuite) Test_ProcessUnassignedChunks() {
@@ -87,7 +88,10 @@ func (suite *JobsSuite) Test_ProcessUnassignedChunks() {
 	// call method under test
 	jobs.ProcessUnassignedChunks(IotaMock)
 
-	suite.Equal(true, sendChunksToChannelMockCalled)
+	time.Sleep(1 * time.Second)
+	//suite.Equal(true, sendChunksToChannelMockCalled_process_unassigned_chunks)
+	time.Sleep(1 * time.Second)
+	//suite.Equal(true, verifyChunkMessagesMatchesRecordMockCalled_process_unassigned_chunks)
 	suite.Equal(31, len(AllChunksCalled))
 
 	/* This test is verifying that the chunks belonging to particular sessions were sent
@@ -127,13 +131,15 @@ func makeMocks_process_unassigned_chunks(iotaMock *services.IotaService) {
 func sendChunksToChannelMock_process_unassigned_chunks(chunks []models.DataMap, channel *models.ChunkChannel) {
 
 	// our mock was called
-	sendChunksToChannelMockCalled = true
+	sendChunksToChannelMockCalled_process_unassigned_chunks = true
 
 	// stored all the chunks that get sent to the mock so we can run tests on them.
 	AllChunksCalled = append(AllChunksCalled, chunks...)
 }
 
 func verifyChunkMessagesMatchesRecordMock_process_unassigned_chunks(chunks []models.DataMap) (filteredChunks services.FilteredChunk, err error) {
+
+	verifyChunkMessagesMatchesRecordMockCalled_process_unassigned_chunks = true
 
 	allDataMaps := []models.DataMap{}
 	err = Suite.DB.All(&allDataMaps)

--- a/jobs/process_unassigned_chunks_test.go
+++ b/jobs/process_unassigned_chunks_test.go
@@ -131,3 +131,23 @@ func sendChunksToChannelMock_process_unassigned_chunks(chunks []models.DataMap, 
 	// stored all the chunks that get sent to the mock so we can run tests on them.
 	AllChunksCalled = append(AllChunksCalled, chunks...)
 }
+
+func verifyChunkMessagesMatchesRecordMock_process_unassigned_chunks(chunks []models.DataMap) (filteredChunks services.FilteredChunk, err error) {
+
+	allDataMaps := []models.DataMap{}
+	err = Suite.DB.All(&allDataMaps)
+	Suite.Nil(err)
+
+	matchesTangle := []models.DataMap{}
+	doesNotMatchTangle := []models.DataMap{}
+	notAttached := []models.DataMap{}
+
+	// assume everything is unattached
+	notAttached = append(notAttached, chunks...)
+
+	return services.FilteredChunk{
+		MatchesTangle:      matchesTangle,
+		NotAttached:        notAttached,
+		DoesNotMatchTangle: doesNotMatchTangle,
+	}, err
+}

--- a/jobs/process_unassigned_chunks_test.go
+++ b/jobs/process_unassigned_chunks_test.go
@@ -88,7 +88,7 @@ func (suite *JobsSuite) Test_ProcessUnassignedChunks() {
 	jobs.ProcessUnassignedChunks(IotaMock)
 
 	suite.Equal(true, sendChunksToChannelMockCalled)
-	suite.Equal(30, len(AllChunksCalled))
+	suite.Equal(31, len(AllChunksCalled))
 
 	/* This test is verifying that the chunks belonging to particular sessions were sent
 	in the order we would expect and that the ordering of chunk ids within each data map was
@@ -112,7 +112,7 @@ func (suite *JobsSuite) Test_ProcessUnassignedChunks() {
 		} else if i > 13 && i < 16 {
 			suite.Equal("genHash1", chunk.GenesisHash)
 			suite.Equal(true, AllChunksCalled[i].ChunkIdx < AllChunksCalled[i+1].ChunkIdx)
-		} else if i > 16 && i < 29 {
+		} else if i > 16 && i < 30 {
 			suite.Equal("genHash3", chunk.GenesisHash)
 			suite.Equal(true, AllChunksCalled[i].ChunkIdx < AllChunksCalled[i+1].ChunkIdx)
 		}

--- a/jobs/process_unassigned_chunks_test.go
+++ b/jobs/process_unassigned_chunks_test.go
@@ -88,10 +88,8 @@ func (suite *JobsSuite) Test_ProcessUnassignedChunks() {
 	// call method under test
 	jobs.ProcessUnassignedChunks(IotaMock)
 
-	time.Sleep(1 * time.Second)
-	//suite.Equal(true, sendChunksToChannelMockCalled_process_unassigned_chunks)
-	time.Sleep(1 * time.Second)
-	//suite.Equal(true, verifyChunkMessagesMatchesRecordMockCalled_process_unassigned_chunks)
+	suite.Equal(true, sendChunksToChannelMockCalled_process_unassigned_chunks)
+	suite.Equal(true, verifyChunkMessagesMatchesRecordMockCalled_process_unassigned_chunks)
 	suite.Equal(31, len(AllChunksCalled))
 
 	/* This test is verifying that the chunks belonging to particular sessions were sent
@@ -124,8 +122,8 @@ func (suite *JobsSuite) Test_ProcessUnassignedChunks() {
 }
 
 func makeMocks_process_unassigned_chunks(iotaMock *services.IotaService) {
-	iotaMock.SendChunksToChannel = sendChunksToChannelMock_process_unassigned_chunks
 	iotaMock.VerifyChunkMessagesMatchRecord = verifyChunkMessagesMatchesRecordMock_process_unassigned_chunks
+	iotaMock.SendChunksToChannel = sendChunksToChannelMock_process_unassigned_chunks
 }
 
 func sendChunksToChannelMock_process_unassigned_chunks(chunks []models.DataMap, channel *models.ChunkChannel) {
@@ -141,15 +139,11 @@ func verifyChunkMessagesMatchesRecordMock_process_unassigned_chunks(chunks []mod
 
 	verifyChunkMessagesMatchesRecordMockCalled_process_unassigned_chunks = true
 
-	allDataMaps := []models.DataMap{}
-	err = Suite.DB.All(&allDataMaps)
-	Suite.Nil(err)
-
 	matchesTangle := []models.DataMap{}
 	doesNotMatchTangle := []models.DataMap{}
 	notAttached := []models.DataMap{}
 
-	// assume everything is unattached
+	// mark everything as unattached
 	notAttached = append(notAttached, chunks...)
 
 	return services.FilteredChunk{

--- a/jobs/process_unassigned_chunks_test.go
+++ b/jobs/process_unassigned_chunks_test.go
@@ -121,6 +121,7 @@ func (suite *JobsSuite) Test_ProcessUnassignedChunks() {
 
 func makeMocks_process_unassigned_chunks(iotaMock *services.IotaService) {
 	iotaMock.SendChunksToChannel = sendChunksToChannelMock_process_unassigned_chunks
+	iotaMock.VerifyChunkMessagesMatchRecord = verifyChunkMessagesMatchesRecordMock_process_unassigned_chunks
 }
 
 func sendChunksToChannelMock_process_unassigned_chunks(chunks []models.DataMap, channel *models.ChunkChannel) {

--- a/main.go
+++ b/main.go
@@ -1,11 +1,13 @@
 package main
 
 import (
+	"github.com/gobuffalo/pop"
 	"github.com/oysterprotocol/brokernode/actions"
 	"log"
 )
 
 func main() {
+	pop.Debug = false
 	app := actions.App()
 	if err := app.Serve(); err != nil {
 		log.Fatal(err)

--- a/models/data_maps.go
+++ b/models/data_maps.go
@@ -127,7 +127,7 @@ func CreateTreasurePayload(ethereumSeed string, sha256Hash string, maxSideChainL
 	keyLocation := rand.Intn(maxSideChainLength)
 
 	currentHash := sha256Hash
-	for i := 0; i < keyLocation; i++ {
+	for i := 0; i <= keyLocation; i++ {
 		currentHash = oyster_utils.HashString(currentHash, sha512.New())
 	}
 

--- a/models/data_maps_test.go
+++ b/models/data_maps_test.go
@@ -61,7 +61,7 @@ func (ms *ModelSuite) Test_CreateTreasurePayload() {
 
 		currentHash := tc.sha256Hash
 
-		for i := 0; i < maxSideChainLength; i++ {
+		for i := 0; i <= maxSideChainLength; i++ {
 			currentHash = oyster_utils.HashString(currentHash, sha512.New())
 			result := oyster_utils.Decrypt(currentHash, string(payloadNotTryted))
 			if result != "" {

--- a/models/upload_sessions.go
+++ b/models/upload_sessions.go
@@ -4,11 +4,10 @@ import (
 	"encoding/json"
 	"math"
 	"time"
-  
-  "github.com/getsentry/raven-go"
+
+	"github.com/getsentry/raven-go"
 	"github.com/gobuffalo/pop"
 	"github.com/gobuffalo/pop/nulls"
-	// "github.com/gobuffalo/pop/slices"
 	"github.com/gobuffalo/uuid"
 	"github.com/gobuffalo/validate"
 	"github.com/gobuffalo/validate/validators"
@@ -210,4 +209,19 @@ func (u *UploadSession) SetTreasureMap(treasureIndexMap []TreasureMap) error {
 
 func getStoragePeg() int {
 	return 1 // TODO: write code to query smart contract to get real storage peg
+}
+
+func GetSessionsByAge() ([]UploadSession, error) {
+
+	sessionsByAge := []UploadSession{}
+
+	err := DB.RawQuery("SELECT * from upload_sessions WHERE payment_status = ? AND "+
+		"treasure_status = ? ORDER BY created_at asc", PaymentStatusPaid, TreasureBuried).All(&sessionsByAge)
+
+	if err != nil {
+		raven.CaptureError(err, nil)
+		return nil, err
+	}
+
+	return sessionsByAge, nil
 }

--- a/services/iota_wrappers.go
+++ b/services/iota_wrappers.go
@@ -269,7 +269,7 @@ func doPowAndBroadcast(branch giota.Trytes, trunk giota.Trytes, depth int64,
 			raven.CaptureError(err, nil)
 		} else {
 
-			fmt.Println("Broadcast Success!")
+			err = api.StoreTransactions(trytes)
 
 			/*
 				TODO do we need this??


### PR DESCRIPTION
Sorry this is so big.  

The "meat and potatoes" of this PR is that it makes the following changes to process_unassigned_chunks:
-When we have available channels, get sessions in order from oldest to newest.  
-For each session, get its unassigned chunks, ordering the chunks according to alpha (asc) or beta (desc) session type.  Only get as many chunks as we can use at a time for the channels we have.
-Assign the chunks to the channels.  

Long-term we want to do something more sophisticated where we will equally distribute the broker's processing power across different data maps, and I started attempting something like that.  Ran into an issue with a flaky test so have commented that code out for now to revisit after mainnet. 


Also included:
-a call to StoreTransactions, the lack of which was causing uploads to seem to not work and chunks to get reattached multiple times
-pop.Debug = false so you don't have to look at a bunch of sql stuff when you're trying to watch the container output
-move some processed_paid_sessions queries to the appropriate model files