### PR TITLE
Can bury dummy treasures

### DIFF
--- a/jobs/process_paid_sessions_test.go
+++ b/jobs/process_paid_sessions_test.go
@@ -24,7 +24,7 @@ func (suite *JobsSuite) Test_ProcessPaidSessions() {
 		"idx": ` + fmt.Sprint(treasureIndexes[5]) + `,
 		"key": "firstKeyFirstMap"
 		},
-		{ 
+		{
 		"sector": 2,
 		"idx": ` + fmt.Sprint(treasureIndexes[78]) + `,
 		"key": "secondKeyFirstMap"
@@ -42,7 +42,7 @@ func (suite *JobsSuite) Test_ProcessPaidSessions() {
 		"idx": 155,
 		"key": "firstKeySecondMap"
 		},
-		{ 
+		{
 		"sector": 2,
 		"idx": 204,
 		"key": "secondKeySecondMap"
@@ -60,7 +60,7 @@ func (suite *JobsSuite) Test_ProcessPaidSessions() {
 		FileSizeBytes:  fileBytesCount,
 		Type:           models.SessionTypeAlpha,
 		PaymentStatus:  models.PaymentStatusPaid,
-		TreasureStatus: models.TreasureUnburied,
+		TreasureStatus: models.TreasureBurying,
 		TreasureIdxMap: nulls.String{string(testMap1), true},
 	}
 

--- a/jobs/update_timed_out_data_maps.go
+++ b/jobs/update_timed_out_data_maps.go
@@ -1,10 +1,12 @@
 package jobs
 
 import (
+	"github.com/oysterprotocol/brokernode/utils"
 	"time"
 
 	raven "github.com/getsentry/raven-go"
 	"github.com/oysterprotocol/brokernode/models"
+	"gopkg.in/segmentio/analytics-go.v3"
 )
 
 func init() {
@@ -21,17 +23,17 @@ func UpdateTimeOutDataMaps(thresholdTime time.Time) {
 
 	if len(timedOutDataMaps) > 0 {
 
-		//when we bring back hooknodes, do decrement somewhere in here
+		//when we bring back hooknodes, do decrement score somewhere in here
 
 		for _, timedOutDataMap := range timedOutDataMaps {
-			//go services.SegmentClient.Enqueue(analytics.Track{
-			//	Event:  "chunk_timed_out",
-			//	UserId: services.GetLocalIP(),
-			//	Properties: analytics.NewProperties().
-			//		Set("address", timedOutDataMap.Address).
-			//		Set("genesis_hash", timedOutDataMap.GenesisHash).
-			//		Set("chunk_idx", timedOutDataMap.ChunkIdx),
-			//})
+			go oyster_utils.SegmentClient.Enqueue(analytics.Track{
+				Event:  "chunk_timed_out",
+				UserId: oyster_utils.GetLocalIP(),
+				Properties: analytics.NewProperties().
+					Set("address", timedOutDataMap.Address).
+					Set("genesis_hash", timedOutDataMap.GenesisHash).
+					Set("chunk_idx", timedOutDataMap.ChunkIdx),
+			})
 
 			timedOutDataMap.Status = models.Unassigned
 			models.DB.ValidateAndSave(&timedOutDataMap)

--- a/jobs/verify_data_maps.go
+++ b/jobs/verify_data_maps.go
@@ -4,6 +4,8 @@ import (
 	raven "github.com/getsentry/raven-go"
 	"github.com/oysterprotocol/brokernode/models"
 	"github.com/oysterprotocol/brokernode/services"
+	"github.com/oysterprotocol/brokernode/utils"
+	"gopkg.in/segmentio/analytics-go.v3"
 )
 
 func init() {
@@ -42,14 +44,14 @@ func CheckChunks(IotaWrapper services.IotaService, unverifiedDataMaps []models.D
 	if len(filteredChunks.MatchesTangle) > 0 {
 
 		for _, matchingChunk := range filteredChunks.MatchesTangle {
-			//go services.SegmentClient.Enqueue(analytics.Track{
-			//	Event:  "chunk_matched_tangle",
-			//	UserId: services.GetLocalIP(),
-			//	Properties: analytics.NewProperties().
-			//		Set("address", matchingChunk.Address).
-			//		Set("genesis_hash", matchingChunk.GenesisHash).
-			//		Set("chunk_idx", matchingChunk.ChunkIdx),
-			//})
+			go oyster_utils.SegmentClient.Enqueue(analytics.Track{
+				Event:  "chunk_matched_tangle",
+				UserId: oyster_utils.GetLocalIP(),
+				Properties: analytics.NewProperties().
+					Set("address", matchingChunk.Address).
+					Set("genesis_hash", matchingChunk.GenesisHash).
+					Set("chunk_idx", matchingChunk.ChunkIdx),
+			})
 
 			matchingChunk.Status = models.Complete
 			models.DB.ValidateAndSave(&matchingChunk)
@@ -61,14 +63,14 @@ func CheckChunks(IotaWrapper services.IotaService, unverifiedDataMaps []models.D
 		// when we bring back hooknodes, decrement their reputation here
 
 		for _, notMatchingChunk := range filteredChunks.DoesNotMatchTangle {
-			//go services.SegmentClient.Enqueue(analytics.Track{
-			//	Event:  "resend_chunk_tangle_mismatch",
-			//	UserId: services.GetLocalIP(),
-			//	Properties: analytics.NewProperties().
-			//		Set("address", notMatchingChunk.Address).
-			//		Set("genesis_hash", notMatchingChunk.GenesisHash).
-			//		Set("chunk_idx", notMatchingChunk.ChunkIdx),
-			//})
+			go oyster_utils.SegmentClient.Enqueue(analytics.Track{
+				Event:  "resend_chunk_tangle_mismatch",
+				UserId: oyster_utils.GetLocalIP(),
+				Properties: analytics.NewProperties().
+					Set("address", notMatchingChunk.Address).
+					Set("genesis_hash", notMatchingChunk.GenesisHash).
+					Set("chunk_idx", notMatchingChunk.ChunkIdx),
+			})
 
 			// if a chunk did not match the tangle in verify_data_maps
 			// we mark it as "Error" and there is no reason to check the tangle

--- a/models/models_test.go
+++ b/models/models_test.go
@@ -2,6 +2,7 @@ package models_test
 
 import (
 	"github.com/gobuffalo/suite"
+	"github.com/oysterprotocol/brokernode/utils"
 	"testing"
 )
 
@@ -10,6 +11,8 @@ type ModelSuite struct {
 }
 
 func Test_ModelSuite(t *testing.T) {
+	defer oyster_utils.ResetBrokerMode()
+	oyster_utils.SetBrokerMode(oyster_utils.ProdMode)
 	as := &ModelSuite{suite.NewModel()}
 	suite.Run(t, as)
 }

--- a/models/upload_sessions.go
+++ b/models/upload_sessions.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"github.com/oysterprotocol/brokernode/utils"
 	"math"
+	"os"
 	"time"
 
 	"github.com/getsentry/raven-go"
@@ -60,7 +61,8 @@ const (
 )
 
 const (
-	TreasureUnburied int = iota + 1
+	TreasureGeneratingKeys int = iota + 1
+	TreasureBurying
 	TreasureBuried
 )
 
@@ -122,9 +124,9 @@ func (u *UploadSession) BeforeCreate(tx *pop.Connection) error {
 			u.PaymentStatus = PaymentStatusPending
 		}
 
-		// Defaults to treasureUnburied
+		// Defaults to treasureGeneratingKeys
 		if u.TreasureStatus == 0 {
-			u.TreasureStatus = TreasureUnburied
+			u.TreasureStatus = TreasureGeneratingKeys
 		}
 	case oyster_utils.TestModeDummyTreasure:
 		// Defaults to paymentStatusPaid
@@ -132,9 +134,9 @@ func (u *UploadSession) BeforeCreate(tx *pop.Connection) error {
 			u.PaymentStatus = PaymentStatusPaid
 		}
 
-		// Defaults to treasureUnburied
+		// Defaults to treasureBurying
 		if u.TreasureStatus == 0 {
-			u.TreasureStatus = TreasureUnburied
+			u.TreasureStatus = TreasureBurying
 		}
 	case oyster_utils.TestModeNoTreasure:
 		// Defaults to paymentStatusPaid
@@ -216,6 +218,7 @@ func (u *UploadSession) GetTreasureMap() ([]TreasureMap, error) {
 			raven.CaptureError(err, nil)
 		}
 	}
+
 	return treasureIndex, err
 }
 
@@ -231,6 +234,46 @@ func (u *UploadSession) SetTreasureMap(treasureIndexMap []TreasureMap) error {
 	u.TreasureIdxMap = nulls.String{string(treasureString), true}
 	DB.ValidateAndSave(u)
 	return nil
+}
+
+// Sets the TreasureIdxMap with Sector, Idx, and Key
+func (u *UploadSession) MakeTreasureIdxMap(alphaIndexes []int, betaIndexs []int) {
+	mergedIndexes, err := oyster_utils.MergeIndexes(alphaIndexes, betaIndexs)
+	treasureIndexArray := make([]TreasureMap, 0)
+
+	key := ""
+
+	if oyster_utils.BrokerMode == oyster_utils.TestModeDummyTreasure {
+		key = os.Getenv("TEST_MODE_WALLET_KEY")
+	}
+
+	for i, mergedIndex := range mergedIndexes {
+		treasureIndexArray = append(treasureIndexArray, TreasureMap{
+			Sector: i,
+			Idx:    mergedIndex,
+			Key:    key, // TODO where are we getting the real keys?
+		})
+	}
+
+	treasureString, err := json.Marshal(treasureIndexArray)
+	if err != nil {
+		raven.CaptureError(err, nil)
+	}
+
+	u.TreasureIdxMap = nulls.String{string(treasureString), true}
+	DB.ValidateAndSave(u)
+}
+
+func (u *UploadSession) GetTreasureIndexes() ([]int, error) {
+	treasureMap, err := u.GetTreasureMap()
+	if err != nil {
+		raven.CaptureError(err, nil)
+	}
+	treasureIndexArray := make([]int, 0)
+	for _, treasure := range treasureMap {
+		treasureIndexArray = append(treasureIndexArray, treasure.Idx)
+	}
+	return treasureIndexArray, err
 }
 
 func (u *UploadSession) BulkMarkDataMapsAsUnassigned() error {
@@ -276,7 +319,7 @@ func GetSessionsThatNeedTreasure() ([]UploadSession, error) {
 	unburiedSessions := []UploadSession{}
 
 	err := DB.Where("payment_status = ? AND treasure_status = ?",
-		PaymentStatusPaid, TreasureUnburied).All(&unburiedSessions)
+		PaymentStatusPaid, TreasureBurying).All(&unburiedSessions)
 
 	return unburiedSessions, err
 }

--- a/utils/mode.go
+++ b/utils/mode.go
@@ -1,8 +1,6 @@
 package oyster_utils
 
 import (
-	"github.com/getsentry/raven-go"
-	"github.com/joho/godotenv"
 	"log"
 	"os"
 )
@@ -19,19 +17,11 @@ var BrokerMode ModeStatus
 
 func init() {
 
-	// Load ENV variables
-	err := godotenv.Load()
-	if err != nil {
-		log.Println("Error loading .env file")
-		raven.CaptureError(err, nil)
-	}
-
-	brokerMode := os.Getenv("MODE")
-
-	SetBrokerMode(brokerMode)
+	ResetBrokerMode()
 }
 
-func SetBrokerMode(brokerMode string) {
+func ResetBrokerMode() {
+	brokerMode := os.Getenv("MODE")
 
 	switch brokerMode {
 	case "PROD_MODE":
@@ -47,4 +37,8 @@ func SetBrokerMode(brokerMode string) {
 		log.Println("No MODE given, defaulting to PROD_MODE")
 		BrokerMode = ProdMode
 	}
+}
+
+func SetBrokerMode(brokerMode ModeStatus) {
+	BrokerMode = brokerMode
 }

--- a/utils/segment_logger.go
+++ b/utils/segment_logger.go
@@ -1,54 +1,61 @@
 package oyster_utils
 
 import (
-//"os"
-//"github.com/joho/godotenv"
-//"net"
-//"time"
-//"github.com/segmentio/analytics-go"
-//"gopkg.in/segmentio/analytics-go.v3"
-//"gopkg.in/segmentio/analytics-go.v3"
-//"github.com/joho/godotenv"
-//"log"
-//"gopkg.in/segmentio/analytics-go.v3"
+	"github.com/iotaledger/giota"
+	"gopkg.in/segmentio/analytics-go.v3"
+	"net"
+	"os"
+	"time"
 )
 
-//var SegmentClient analytics.Client
+var (
+	segmentWriteKey string
+	SegmentClient   analytics.Client
+)
 
 func init() {
-	// Load ENV variables
-	//err := godotenv.Load()
-	//if err != nil {
-	//	//log.Fatal("Error loading .env file")
-	//}
-	//
 	//// Setup Segment
-	//SegmentClient = analytics.New(os.Getenv("SEGMENT_WRITE_KEY"))
+	segmentWriteKey = os.Getenv("SEGMENT_WRITE_KEY")
+	if segmentWriteKey != "" {
+		SegmentClient = analytics.New(segmentWriteKey)
+	}
 }
 
 func GetLocalIP() string {
-	//addrs, err := net.InterfaceAddrs()
-	//if err != nil {
-	//	return ""
-	//}
-	//for _, address := range addrs {
-	//	// check the address type and if it is not a loopback the display it
-	//	if ipnet, ok := address.(*net.IPNet); ok && !ipnet.IP.IsLoopback() {
-	//		if ipnet.IP.To4() != nil {
-	//			return ipnet.IP.String()
-	//		}
-	//	}
-	//}
+	addrs, err := net.InterfaceAddrs()
+	if err != nil {
+		return ""
+	}
+	for _, address := range addrs {
+		// check the address type and if it is not a loopback the display it
+		if ipnet, ok := address.(*net.IPNet); ok && !ipnet.IP.IsLoopback() {
+			if ipnet.IP.To4() != nil {
+				return ipnet.IP.String()
+			}
+		}
+	}
 	return ""
 }
 
-//func TimeTrack(start time.Time, name string, properties analytics.Properties) {
-//elapsed := time.Since(start).Seconds()
-//
-//go SegmentClient.Enqueue(analytics.Track{
-//	Event:  name,
-//	UserId: GetLocalIP(),
-//	Properties: properties.
-//		Set("time_elapsed", elapsed),
-//})
-//}
+func MapTransactionsToAddrs(txs []giota.Transaction) (addrs []giota.Address) {
+
+	addrs = make([]giota.Address, 0, len(txs))
+
+	for _, tx := range txs {
+		addrs = append(addrs, tx.Address)
+	}
+	return
+}
+
+func TimeTrack(start time.Time, name string, properties analytics.Properties) {
+	if segmentWriteKey != "" {
+		elapsed := time.Since(start).Seconds()
+
+		go SegmentClient.Enqueue(analytics.Track{
+			Event:  name,
+			UserId: GetLocalIP(),
+			Properties: properties.
+				Set("time_elapsed", elapsed),
+		})
+	}
+}

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -119,7 +119,7 @@ func GenerateInsertedIndexesForPearl(fileSizeInByte int) []int {
 
 // Return the IdxMap for treasure to burried
 func GetTreasureIdxMap(alphaIndexes []int, betaIndexs []int) nulls.String {
-	mergedIndexes, err := mergeIndexes(alphaIndexes, betaIndexs)
+	mergedIndexes, err := MergeIndexes(alphaIndexes, betaIndexs)
 	var idxMap nulls.String
 	if err == nil {
 		idxMap = nulls.NewString(IntsJoin(mergedIndexes, IntsJoinDelim))
@@ -178,7 +178,7 @@ func IntsSplit(a string, delim string) []int {
 
 // Private methods
 // Merge 2 different indexes into 1 indexes. Computed Merged indexes
-func mergeIndexes(a []int, b []int) ([]int, error) {
+func MergeIndexes(a []int, b []int) ([]int, error) {
 	var merged []int
 	if len(a) == 0 && len(b) == 0 || len(a) != len(b) {
 		return nil, errors.New("Invalid input")

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -149,19 +149,19 @@ func Test_GenerateInsertIndexesForPearl_NotNeedToExtendedToNextSector(t *testing
 }
 
 func Test_MergedIndexes_EmptyIndexes(t *testing.T) {
-	_, err := mergeIndexes([]int{}, nil)
+	_, err := MergeIndexes([]int{}, nil)
 
 	assertTrue(err != nil, t, "")
 }
 
 func Test_MergedIndexes_OneNonEmptyIndexes(t *testing.T) {
-	_, err := mergeIndexes(nil, []int{1, 2})
+	_, err := MergeIndexes(nil, []int{1, 2})
 
 	assertTrue(err != nil, t, "Must result an error")
 }
 
 func Test_MergeIndexes_SameSize(t *testing.T) {
-	indexes, _ := mergeIndexes([]int{1, 2, 3}, []int{1, 2, 3})
+	indexes, _ := MergeIndexes([]int{1, 2, 3}, []int{1, 2, 3})
 
 	assertTrue(len(indexes) == 3, t, "Must result an error")
 }


### PR DESCRIPTION
-Can bury a dummy treasure if broker is in TEST_MODE_DUMMY_TREASURE
-Sets broker to PROD_MODE while test suites are being run
-Enables Segment logging
-Changes the treasure statuses to make them more clear
-Updates the TreasureIdxMaps to store the following properties for each entry in the array:  Sector, Idx, Key