### PR TITLE
Add ComputeSectorHashes method to compute a list of hashes from genHash

### DIFF
--- a/models/data_maps.go
+++ b/models/data_maps.go
@@ -106,6 +106,22 @@ func (d *DataMap) ValidateUpdate(tx *pop.Connection) (*validate.Errors, error) {
 	return validate.NewErrors(), nil
 }
 
+// Computes a particular sectorIdx hashes. Limit by maxNumbOfHashes.
+func ComputeSectorHashes(genHash string, sectorIdx int, maxNumOfHashes int) []string {
+	var hashes []string
+
+	currHash := genHash
+	for i := 0; i < sectorIdx*oyster_utils.FileSectorInChunkSize; i++ {
+		currHash = oyster_utils.HashString(currHash, sha256.New())
+	}
+
+	for i := 0; i < maxNumOfHashes; i++ {
+		hashes = append(hashes, currHash)
+		currHash = oyster_utils.HashString(currHash, sha256.New())
+	}
+	return hashes
+}
+
 // BuildDataMaps builds the datamap and inserts them into the DB.
 func BuildDataMaps(genHash string, numChunks int) (vErr *validate.Errors, err error) {
 

--- a/models/data_maps_test.go
+++ b/models/data_maps_test.go
@@ -261,6 +261,19 @@ func (suite *ModelSuite) Test_GetUnassignedChunksBySession() {
 	suite.NotEqual(models.DataMap{}, chunksWithLimit[0])
 }
 
+func (suite *ModelSuite) Test_ComputeSectorHashes_AtSectorZero() {
+	hashes := models.ComputeSectorHashes("genHash", 0, 2)
+
+	suite.Equal(hashes, []string{"genHash", "7000556e041504a06cfc3f08e1dda5500ed3a4157635054b392347a060df8b43"})
+}
+
+func (suite *ModelSuite) Test_ComputerSectorHashes_AtSectorOne() {
+	hashes := models.ComputeSectorHashes("genHash", 1, 2)
+
+	suite.Equal(hashes, []string{"0da27899301775e74175fc6394839db94aa67f59c0dcfeeb67f19e42d1c1008e",
+		"af270fbe08f2c6b1c3476870d28019a7d2c6e607e320da56e137967a87cc4e52"})
+}
+
 func (suite *ModelSuite) Test_AttachUnassignedChunksToGenHashMap() {
 
 	/*TODO


### PR DESCRIPTION
This is used in v2/treasure/.

The brokernode will on the fly generate the hash and verify them on the IOTA to make sure this is inserted correctly.