### PR TITLE
Better encryption

### DIFF
--- a/models/data_maps.go
+++ b/models/data_maps.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha512"
 	"encoding/json"
 	"github.com/getsentry/raven-go"
+	"golang.org/x/crypto/sha3"
 	"math/rand"
 
 	"time"
@@ -173,11 +174,12 @@ func CreateTreasurePayload(ethereumSeed string, sha256Hash string, maxSideChainL
 
 	currentHash := sha256Hash
 	for i := 0; i <= keyLocation; i++ {
-		currentHash = oyster_utils.HashString(currentHash, sha512.New())
+		currentHash = oyster_utils.HashString(currentHash, sha3.New256())
 	}
 
-	encryptedResult := oyster_utils.Encrypt(currentHash, ethereumSeed)
-	return string(oyster_utils.BytesToTrytes([]byte(encryptedResult))), nil
+	encryptedResult := oyster_utils.Encrypt(currentHash, ethereumSeed, sha256Hash)
+
+	return string(oyster_utils.BytesToTrytes(encryptedResult)), nil
 }
 
 func GetUnassignedGenesisHashes() ([]interface{}, error) {

--- a/models/data_maps_test.go
+++ b/models/data_maps_test.go
@@ -1,12 +1,12 @@
 package models_test
 
 import (
-	"crypto/sha512"
+	"encoding/hex"
+	"github.com/iotaledger/giota"
 	"github.com/oysterprotocol/brokernode/jobs"
 	"github.com/oysterprotocol/brokernode/models"
 	"github.com/oysterprotocol/brokernode/utils"
-
-	"github.com/iotaledger/giota"
+	"golang.org/x/crypto/sha3"
 )
 
 type hashAddressConversion struct {
@@ -60,15 +60,15 @@ func (ms *ModelSuite) Test_CreateTreasurePayload() {
 		payload, err := models.CreateTreasurePayload(tc.ethPrivateSeed, tc.sha256Hash, maxSideChainLength)
 		ms.Nil(err)
 
-		payloadNotTryted := oyster_utils.TrytesToBytes(giota.Trytes(payload))
+		payloadInBytes := oyster_utils.TrytesToBytes(giota.Trytes(payload))
 
 		currentHash := tc.sha256Hash
 
 		for i := 0; i <= maxSideChainLength; i++ {
-			currentHash = oyster_utils.HashString(currentHash, sha512.New())
-			result := oyster_utils.Decrypt(currentHash, string(payloadNotTryted))
-			if result != "" {
-				ms.Equal(result, tc.ethPrivateSeed)
+			currentHash = oyster_utils.HashString(currentHash, sha3.New256())
+			result := oyster_utils.Decrypt(currentHash, hex.EncodeToString(payloadInBytes), tc.sha256Hash)
+			if result != nil {
+				ms.Equal(string(result), tc.ethPrivateSeed)
 				matchesFound++
 			}
 		}

--- a/utils/cryptography.go
+++ b/utils/cryptography.go
@@ -3,51 +3,51 @@ package oyster_utils
 import (
 	"crypto/aes"
 	"crypto/cipher"
-	"crypto/rand"
-	"crypto/sha256"
 	"encoding/hex"
 	"hash"
-	"strings"
-
-	"golang.org/x/crypto/pbkdf2"
 )
 
-func deriveKey(passphrase string, salt []byte) ([]byte, []byte) {
-	if salt == nil {
-		salt = make([]byte, 8)
-		// http://www.ietf.org/rfc/rfc2898.txt
-		// Salt.
-		rand.Read(salt)
+func Encrypt(key string, secret string, nonce string) []byte {
+	keyInBytes, err := hex.DecodeString(key)
+	panicOnErr(err)
+	block, err := aes.NewCipher(keyInBytes)
+	panicOnErr(err)
+	gcm, err := cipher.NewGCM(block)
+	panicOnErr(err)
+	nonceInBytes, err := hex.DecodeString(nonce[0 : 2*gcm.NonceSize()])
+	panicOnErr(err)
+	data := gcm.Seal(nil, nonceInBytes, []byte(secret), nil)
+	return data
+}
+
+func Decrypt(key string, cipherText string, nonce string) []byte {
+	keyInBytes, err := hex.DecodeString(key)
+	panicOnErr(err)
+	data, err := hex.DecodeString(cipherText)
+	panicOnErr(err)
+	block, err := aes.NewCipher(keyInBytes)
+	panicOnErr(err)
+	gcm, err := cipher.NewGCM(block)
+	panicOnErr(err)
+	nonceInBytes, err := hex.DecodeString(nonce[0 : 2*gcm.NonceSize()])
+	panicOnErr(err)
+	data, err = gcm.Open(nil, nonceInBytes, data, nil)
+	if err != nil {
+		return nil
 	}
-	return pbkdf2.Key([]byte(passphrase), salt, 1000, 32, sha256.New), salt
-}
-
-func Encrypt(passphrase, plaintext string) string {
-	key, salt := deriveKey(passphrase, nil)
-	iv := make([]byte, 12)
-	// http://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication800-38d.pdf
-	// Section 8.2
-	rand.Read(iv)
-	b, _ := aes.NewCipher(key)
-	aesgcm, _ := cipher.NewGCM(b)
-	data := aesgcm.Seal(nil, iv, []byte(plaintext), nil)
-	return hex.EncodeToString(salt) + "-" + hex.EncodeToString(iv) + "-" + hex.EncodeToString(data)
-}
-
-func Decrypt(passphrase, ciphertext string) string {
-	arr := strings.Split(ciphertext, "-")
-	salt, _ := hex.DecodeString(arr[0])
-	iv, _ := hex.DecodeString(arr[1])
-	data, _ := hex.DecodeString(arr[2])
-	key, _ := deriveKey(passphrase, salt)
-	b, _ := aes.NewCipher(key)
-	aesgcm, _ := cipher.NewGCM(b)
-	data, _ = aesgcm.Open(nil, iv, data, nil)
-	return string(data)
+	return data
 }
 
 func HashString(str string, shaAlg hash.Hash) (h string) {
 	shaAlg.Write([]byte(str))
 	h = hex.EncodeToString(shaAlg.Sum(nil))
 	return
+}
+
+func panicOnErr(err error) {
+	// this is just so that the same 3 lines aren't repeated
+	// throughout the encrypt/decrypt functions
+	if err != nil {
+		panic(err.Error())
+	}
 }

--- a/utils/cryptography_test.go
+++ b/utils/cryptography_test.go
@@ -1,1 +1,55 @@
-package oyster_utils
+package oyster_utils_test
+
+import (
+	"encoding/hex"
+	"github.com/oysterprotocol/brokernode/utils"
+	"testing"
+)
+
+type EncryptionTestStruct struct {
+	key    string
+	secret string
+	nonce  string
+	result string
+}
+
+var encryptionTestCases = []EncryptionTestStruct{
+	{
+		key:    "64dc1ce4655554f514a4ce83e08c1d08372fdf02bd8c9b6dbecfc74b783d39d1",
+		secret: "0000000000000000000000000000000000000000000000000000000000000001",
+		nonce:  "948791aa5dfd8f71405da35c637ad58cc9f5fec7424dba3e97630921e130c5b6",
+		result: "691da3d38bb9c8b36ca979763a1b31a5d8daa16e427a0583f72396102cd9703378244ef3a08191754ceb61e2959561d52a8db41fa620a3c2c77d24ae8725386f58c962712d6bd659860f53eab91a8328",
+	},
+	{
+		key:    "99577b266e77d07e364d0b87bf1bcef44c78e3668dfdc3881969b375c09d4fcd",
+		secret: "1004444400000006780000000000000000000000000012345000000765430001",
+		nonce:  "23384a8eabc4a4ba091cfdbcb3dbacdc27000c03e318fd52accb8e2380f11320",
+		result: "52cf25f81f4be93699c91176cee581aedf18da38e03df5bf05fdd4cff5c3d03d261c8f974452d9b78fc5aa392042ec0f52eea73caee1c9d8bc51db16088ac5e10e141162d52b3a165635c7522e07a7a4",
+	},
+	{
+		key:    "7fb4ca9cc0032bafc2ebd0fda018a41f5adfcf441123de22ab736a42207933f7",
+		secret: "7777777774444444777777744444447777777444444777777744444777777744",
+		nonce:  "0d412fa10c9027b7163302e38c96a5c0904b1b04cb55c66162296d0be2e3caa2",
+		result: "cac5deda652c5ba021108693f4ef2e5d87170742886ab6c848b73de1c431adbfdb6936a0b37d4089a96572d4a74707127b16d605bbd0c17dd12e91fd660806e2e394e9762883228c66866592d8c9e052",
+	},
+}
+
+func Test_Encrypt(t *testing.T) {
+	for _, tc := range encryptionTestCases {
+		result := oyster_utils.Encrypt(tc.key, tc.secret, tc.nonce)
+		if hex.EncodeToString(result) != tc.result {
+			t.Fatalf("Encrypt() result should be %s but returned %s",
+				tc.result, hex.EncodeToString(result))
+		}
+	}
+}
+
+func Test_Decrypt(t *testing.T) {
+	for _, tc := range encryptionTestCases {
+		secret := oyster_utils.Decrypt(tc.key, tc.result, tc.nonce)
+		if string(secret) != tc.secret {
+			t.Fatalf("Decrypt() should be %s but returned %s",
+				tc.secret, string(secret))
+		}
+	}
+}


### PR DESCRIPTION
-Remove salt
-Remove iv
-Use sha256 hash as the nonce.  Have to trim it according to GCM's nonce size
-Use sha3-256 instead of sha512 hashes as the keys
-Remove deriveKey method and just use the key we tell it to
-Add tests for encryption and decryption methods, we can also use these test vectors if we write encryption/decryption tests on the webnode
-Update CreateTreasurePayload method
-Encrypt and Decrypt methods now return []bytes
-Panic on every single error