### PR TITLE
process_unassigned_chunks frequency changes dynamically

### DIFF
--- a/jobs/job_runner.go
+++ b/jobs/job_runner.go
@@ -6,7 +6,7 @@ import (
 	"time"
 )
 
-var BundleSize = 30
+var BundleSize = 100
 
 var OysterWorker = worker.NewSimple()
 
@@ -42,7 +42,7 @@ func doWork(oysterWorker *worker.Simple) {
 		Queue:   "default",
 		Handler: "processUnassignedChunksHandler",
 		Args: worker.Args{
-			"duration": 20 * time.Second,
+			"duration": time.Duration(services.GetProcessingFrequency()) * time.Second,
 		},
 	}
 
@@ -115,8 +115,11 @@ var processUnassignedChunksHandler = func(args worker.Args) error {
 	processUnassignedChunksJob := worker.Job{
 		Queue:   "default",
 		Handler: "processUnassignedChunksHandler",
-		Args:    args,
+		Args: worker.Args{
+			"duration": time.Duration(services.GetProcessingFrequency()) * time.Second,
+		},
 	}
+
 	OysterWorker.PerformIn(processUnassignedChunksJob, processUnassignedChunksJob.Args["duration"].(time.Duration))
 
 	return nil

--- a/services/iota_wrappers_test.go
+++ b/services/iota_wrappers_test.go
@@ -80,6 +80,8 @@ func Test_TrackProcessingTime(t *testing.T) {
 
 	initialLastChunkRecord := ((*(powChannel.ChunkTrackers))[len(*powChannel.ChunkTrackers)-1])
 
+	initialPoWFrequency := services.PoWFrequency.Frequency
+
 	services.TrackProcessingTime(startTime, 10, &powChannel)
 
 	newLastChunkRecord := ((*(powChannel.ChunkTrackers))[len(*powChannel.ChunkTrackers)-1])
@@ -98,5 +100,9 @@ func Test_TrackProcessingTime(t *testing.T) {
 	// check that there are only 10 records
 	if len(*powChannel.ChunkTrackers) != 10 {
 		t.Fatalf("TrackProcessingTime:  only supposed to hold the last 10 records")
+	}
+
+	if initialPoWFrequency == services.GetProcessingFrequency() {
+		t.Fatalf("TrackProcessingTime:  PoWFrequency.Frequency should have changed")
 	}
 }


### PR DESCRIPTION
The PoW is so fast now that the broker just sits there doing nothing between process_unassigned_chunks runs.  

This PR:
-increases the bundle size so that every PoW process on the broker will take a little longer.  About 3 seconds with this bundle size.
-configures process_unassigned_chunks frequency to change dynamically according to how quick PoW usually is.  We can freely change BundleSize and the frequency the task gets ran will automagically adjust.