### PR TITLE
Adds new payment status, updates payment polling GET, updates unit te…

### DIFF
--- a/actions/upload_sessions_test.go
+++ b/actions/upload_sessions_test.go
@@ -62,7 +62,7 @@ func (as *ActionSuite) Test_UploadSessionsGetPaymentStatus_Paid() {
 		GenesisHash:   "genHash1",
 		FileSizeBytes: 123,
 		NumChunks:     2,
-		PaymentStatus: models.PaymentStatusPaid,
+		PaymentStatus: models.PaymentStatusConfirmed,
 	}
 
 	uploadSession1.StartUploadSession()
@@ -81,7 +81,7 @@ func (as *ActionSuite) Test_UploadSessionsGetPaymentStatus_Paid() {
 	err = json.Unmarshal(bodyBytes, &resParsed)
 	as.Nil(err)
 
-	as.Equal("paid", resParsed.PaymentStatus)
+	as.Equal("confirmed", resParsed.PaymentStatus)
 }
 
 func (as *ActionSuite) Test_UploadSessionsGetPaymentStatus_Pending() {
@@ -110,6 +110,34 @@ func (as *ActionSuite) Test_UploadSessionsGetPaymentStatus_Pending() {
 	as.Nil(err)
 
 	as.Equal("pending", resParsed.PaymentStatus)
+}
+
+func (as *ActionSuite) Test_UploadSessionsGetPaymentStatus_Invoiced() {
+	//setup
+	uploadSession1 := models.UploadSession{
+		GenesisHash:   "genHash1",
+		FileSizeBytes: 123,
+		NumChunks:     2,
+		PaymentStatus: models.PaymentStatusInvoiced,
+	}
+
+	uploadSession1.StartUploadSession()
+
+	session := models.UploadSession{}
+	err := as.DB.Where("genesis_hash = ?", "genHash1").First(&session)
+	as.Equal(err, nil)
+
+	//execute method
+	res := as.JSON("/api/v2/upload-sessions/" + fmt.Sprint(session.ID)).Get()
+
+	// Parse response
+	resParsed := paymentStatusCreateRes{}
+	bodyBytes, err := ioutil.ReadAll(res.Body)
+	as.Nil(err)
+	err = json.Unmarshal(bodyBytes, &resParsed)
+	as.Nil(err)
+
+	as.Equal("invoiced", resParsed.PaymentStatus)
 }
 
 func (as *ActionSuite) Test_UploadSessionsGetPaymentStatus_Error() {

--- a/jobs/process_paid_sessions_test.go
+++ b/jobs/process_paid_sessions_test.go
@@ -59,7 +59,7 @@ func (suite *JobsSuite) Test_ProcessPaidSessions() {
 		NumChunks:      500,
 		FileSizeBytes:  fileBytesCount,
 		Type:           models.SessionTypeAlpha,
-		PaymentStatus:  models.PaymentStatusPaid,
+		PaymentStatus:  models.PaymentStatusConfirmed,
 		TreasureStatus: models.TreasureBurying,
 		TreasureIdxMap: nulls.String{string(testMap1), true},
 	}
@@ -72,7 +72,7 @@ func (suite *JobsSuite) Test_ProcessPaidSessions() {
 		NumChunks:      500,
 		FileSizeBytes:  fileBytesCount,
 		Type:           models.SessionTypeAlpha,
-		PaymentStatus:  models.PaymentStatusPaid,
+		PaymentStatus:  models.PaymentStatusConfirmed,
 		TreasureStatus: models.TreasureBuried,
 		TreasureIdxMap: nulls.String{string(testMap2), true},
 	}

--- a/jobs/process_unassigned_chunks_test.go
+++ b/jobs/process_unassigned_chunks_test.go
@@ -34,7 +34,7 @@ func (suite *JobsSuite) Test_ProcessUnassignedChunks() {
 		NumChunks:      numChunks,
 		FileSizeBytes:  3000,
 		Type:           models.SessionTypeAlpha,
-		PaymentStatus:  models.PaymentStatusPaid,
+		PaymentStatus:  models.PaymentStatusConfirmed,
 		TreasureStatus: models.TreasureBuried,
 	}
 
@@ -43,7 +43,7 @@ func (suite *JobsSuite) Test_ProcessUnassignedChunks() {
 		NumChunks:      numChunks,
 		FileSizeBytes:  3000,
 		Type:           models.SessionTypeBeta,
-		PaymentStatus:  models.PaymentStatusPaid,
+		PaymentStatus:  models.PaymentStatusConfirmed,
 		TreasureStatus: models.TreasureBuried,
 	}
 
@@ -52,7 +52,7 @@ func (suite *JobsSuite) Test_ProcessUnassignedChunks() {
 		NumChunks:      numChunks,
 		FileSizeBytes:  3000,
 		Type:           models.SessionTypeAlpha,
-		PaymentStatus:  models.PaymentStatusPaid,
+		PaymentStatus:  models.PaymentStatusConfirmed,
 		TreasureStatus: models.TreasureBuried,
 	}
 
@@ -61,7 +61,7 @@ func (suite *JobsSuite) Test_ProcessUnassignedChunks() {
 		NumChunks:      numChunks,
 		FileSizeBytes:  3000,
 		Type:           models.SessionTypeBeta,
-		PaymentStatus:  models.PaymentStatusPaid,
+		PaymentStatus:  models.PaymentStatusConfirmed,
 		TreasureStatus: models.TreasureBuried,
 	}
 

--- a/models/data_maps_test.go
+++ b/models/data_maps_test.go
@@ -201,7 +201,7 @@ func (suite *ModelSuite) Test_GetAllUnassignedChunksBySession() {
 		FileSizeBytes:  8000,
 		NumChunks:      numChunks,
 		Type:           models.SessionTypeAlpha,
-		PaymentStatus:  models.PaymentStatusPaid,
+		PaymentStatus:  models.PaymentStatusConfirmed,
 		TreasureStatus: models.TreasureBuried,
 	}
 	uploadSession1.StartUploadSession()
@@ -234,7 +234,7 @@ func (suite *ModelSuite) Test_GetUnassignedChunksBySession() {
 		FileSizeBytes:  8000,
 		NumChunks:      numChunks,
 		Type:           models.SessionTypeAlpha,
-		PaymentStatus:  models.PaymentStatusPaid,
+		PaymentStatus:  models.PaymentStatusConfirmed,
 		TreasureStatus: models.TreasureBuried,
 	}
 	uploadSession1.StartUploadSession()

--- a/models/upload_sessions_test.go
+++ b/models/upload_sessions_test.go
@@ -137,7 +137,7 @@ func (ms *ModelSuite) Test_GetSessionsByAge() {
 		FileSizeBytes:  5000,
 		NumChunks:      7,
 		Type:           models.SessionTypeAlpha,
-		PaymentStatus:  models.PaymentStatusPaid,
+		PaymentStatus:  models.PaymentStatusConfirmed,
 		TreasureStatus: models.TreasureBuried,
 	}
 	uploadSession2 := models.UploadSession{ // this one will be newest and last in the array
@@ -145,7 +145,7 @@ func (ms *ModelSuite) Test_GetSessionsByAge() {
 		FileSizeBytes:  5000,
 		NumChunks:      7,
 		Type:           models.SessionTypeBeta,
-		PaymentStatus:  models.PaymentStatusPaid,
+		PaymentStatus:  models.PaymentStatusConfirmed,
 		TreasureStatus: models.TreasureBuried,
 	}
 	uploadSession3 := models.UploadSession{ // this one will be oldest and first in the array
@@ -153,7 +153,7 @@ func (ms *ModelSuite) Test_GetSessionsByAge() {
 		FileSizeBytes:  5000,
 		NumChunks:      7,
 		Type:           models.SessionTypeBeta,
-		PaymentStatus:  models.PaymentStatusPaid,
+		PaymentStatus:  models.PaymentStatusConfirmed,
 		TreasureStatus: models.TreasureBuried,
 	}
 	uploadSession4 := models.UploadSession{ // will not be in the array
@@ -161,7 +161,7 @@ func (ms *ModelSuite) Test_GetSessionsByAge() {
 		FileSizeBytes:  5000,
 		NumChunks:      7,
 		Type:           models.SessionTypeBeta,
-		PaymentStatus:  models.PaymentStatusPaid,
+		PaymentStatus:  models.PaymentStatusConfirmed,
 		TreasureStatus: models.TreasureBurying,
 	}
 	uploadSession5 := models.UploadSession{ // will not be in the array


### PR DESCRIPTION
-We now have 4 payment statues on the brokernode, PaymentStatusInvoiced, PaymentStatusPending, and PaymentStatusConfirmed, and PaymentStatusError
-In response to webinterface polling, respond with "invoiced" (no payment initiated yet), "pending" (payment initiated but not confirmed, the screen with the spinner), "confirmed" (payment complete, uploading in progress), or "error"
-Updates unit tests