### PR TITLE
Add NotifyBeta API endpoint for Alpha to call

### DIFF
--- a/actions/app.go
+++ b/actions/app.go
@@ -71,6 +71,7 @@ func App() *buffalo.App {
 		apiV2.POST("upload-sessions", uploadSessionResource.Create)
 		apiV2.PUT("upload-sessions/{id}", uploadSessionResource.Update)
 		apiV2.POST("upload-sessions/beta", uploadSessionResource.CreateBeta)
+		apiV2.POST("upload-sessions/notifyBeta", uploadSessionResource.NotifyBeta)
 		apiV2.GET("upload-sessions/{id}", uploadSessionResource.GetPaymentStatus)
 
 		// Webnodes


### PR DESCRIPTION
Allow Alpha to call NotifyBeta once the ETH transfer is completed and update Beta's payment status.

This API should only for Alpha Node.
Next PR: Add logic on the alpha side to wait for Transfer and call NotifyBeta API endpoint
