### PR TITLE
generate eth address from private key

### DIFF
--- a/actions/treasures.go
+++ b/actions/treasures.go
@@ -16,7 +16,6 @@ type treasureReq struct {
 	GenesisHash     string `json:"genesisHash"`
 	SectorIdx       int    `json:"sectorIdx"`
 	NumChunks       int    `json:"numChunks"`
-	EthAddr         string `json:"ethAddr"`
 	EthKey          string `json:"ethKey"`
 }
 
@@ -36,8 +35,10 @@ func (t *TreasuresResource) VerifyAndClaim(c buffalo.Context) error {
 	addr := models.ComputeSectorDataMapAddress(req.GenesisHash, req.SectorIdx, req.NumChunks)
 	verify, err := IotaWrapper.VerifyTreasure(addr)
 
-	if err == nil && verify {
-		verify = EthWrapper.ClaimPRL(services.StringToAddress(req.ReceiverEthAddr), services.StringToAddress(req.EthAddr), req.EthKey)
+	ethAddr, addrErr := EthWrapper.GenerateEthAddrFromPrivateKey(req.EthKey)
+
+	if err == nil && verify && addrErr == nil {
+		verify = EthWrapper.ClaimPRL(services.StringToAddress(req.ReceiverEthAddr), ethAddr, req.EthKey)
 	}
 
 	res := treasureRes{

--- a/actions/treasures.go
+++ b/actions/treasures.go
@@ -35,9 +35,8 @@ func (t *TreasuresResource) VerifyAndClaim(c buffalo.Context) error {
 	addr := models.ComputeSectorDataMapAddress(req.GenesisHash, req.SectorIdx, req.NumChunks)
 	verify, err := IotaWrapper.VerifyTreasure(addr)
 
-	ethAddr, addrErr := EthWrapper.GenerateEthAddrFromPrivateKey(req.EthKey)
-
-	if err == nil && verify && addrErr == nil {
+	if err == nil && verify {
+		ethAddr := EthWrapper.GenerateEthAddrFromPrivateKey(req.EthKey)
 		verify = EthWrapper.ClaimPRL(services.StringToAddress(req.ReceiverEthAddr), ethAddr, req.EthKey)
 	}
 

--- a/actions/treasures_test.go
+++ b/actions/treasures_test.go
@@ -60,8 +60,7 @@ func (as *ActionSuite) Test_VerifyTreasureAndClaim_Success() {
 	// Check mockClaimPrl
 	as.True(mockClaimPrl.hasCalled)
 	as.Equal(services.StringToAddress("receiverEthAddr"), mockClaimPrl.input_receiver_addr)
-	address, err := EthWrapper.GenerateEthAddrFromPrivateKey(ethKey)
-	as.Nil(err)
+	address := EthWrapper.GenerateEthAddrFromPrivateKey(ethKey)
 	as.Equal(address, mockClaimPrl.input_treasure_addr)
 	as.Equal(ethKey, mockClaimPrl.input_treasure_key)
 

--- a/services/eth_gateway.go
+++ b/services/eth_gateway.go
@@ -57,7 +57,7 @@ type OysterCallMsg struct {
 
 type SendGas func([]models.CompletedUpload) error
 type GenerateEthAddr func() (addr common.Address, privateKey string, err error)
-type GenerateEthAddrFromPrivateKey func(privateKey string) (addr common.Address, err error)
+type GenerateEthAddrFromPrivateKey func(privateKey string) (addr common.Address)
 type GetGasPrice func() (*big.Int, error)
 type WaitForTransfer func(brokerAddr common.Address) bool
 type SubscribeToTransfer func(brokerAddr common.Address, outCh chan<- types.Log)
@@ -148,23 +148,23 @@ func generateEthAddr() (addr common.Address, privateKey string, err error) {
 }
 
 // Generate an Ethereum address from a private key
-func generateEthAddrFromPrivateKey(privateKey string) (addr common.Address, err error) {
+func generateEthAddrFromPrivateKey(privateKey string) (addr common.Address) {
 	if privateKey[0:2] != "0x" && privateKey[0:2] != "0X" {
 		privateKey = "0x" + privateKey
 	}
 	privateKeyBigInt := hexutil.MustDecodeBig(privateKey)
-	ethAccount, err := generatePublicKeyFromPrivateKey(crypto.S256(), privateKeyBigInt)
+	ethAccount := generatePublicKeyFromPrivateKey(crypto.S256(), privateKeyBigInt)
 	addr = crypto.PubkeyToAddress(ethAccount.PublicKey)
-	return addr, err
+	return addr
 }
 
 // GenerateKey generates a public and private key pair.
-func generatePublicKeyFromPrivateKey(c elliptic.Curve, k *big.Int) (*ecdsa.PrivateKey, error) {
+func generatePublicKeyFromPrivateKey(c elliptic.Curve, k *big.Int) *ecdsa.PrivateKey {
 	privateKey := new(ecdsa.PrivateKey)
 	privateKey.PublicKey.Curve = c
 	privateKey.D = k
 	privateKey.PublicKey.X, privateKey.PublicKey.Y = c.ScalarBaseMult(k.Bytes())
-	return privateKey, nil
+	return privateKey
 }
 
 // returns represents the 20 byte address of an ethereum account.

--- a/services/eth_gateway.go
+++ b/services/eth_gateway.go
@@ -3,6 +3,7 @@ package services
 import (
 	"context"
 	"crypto/ecdsa"
+	"crypto/elliptic"
 	"encoding/hex"
 	"fmt"
 	"log"
@@ -15,6 +16,7 @@ import (
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ethereum/go-ethereum/crypto"
@@ -30,6 +32,7 @@ type Eth struct {
 	ClaimPRL
 	ClaimUnusedPRLs
 	GenerateEthAddr
+	GenerateEthAddrFromPrivateKey
 	BuryPrl
 	SendETH
 	SendPRL
@@ -54,6 +57,7 @@ type OysterCallMsg struct {
 
 type SendGas func([]models.CompletedUpload) error
 type GenerateEthAddr func() (addr common.Address, privateKey string, err error)
+type GenerateEthAddrFromPrivateKey func(privateKey string) (addr common.Address, err error)
 type GetGasPrice func() (*big.Int, error)
 type WaitForTransfer func(brokerAddr common.Address) bool
 type SubscribeToTransfer func(brokerAddr common.Address, outCh chan<- types.Log)
@@ -93,10 +97,11 @@ func init() {
 	fmt.Println(ethUrl)
 
 	EthWrapper = Eth{
-		SendGas:             sendGas,
-		ClaimPRL:            claimPRLs,
-		ClaimUnusedPRLs:     claimUnusedPRLs,
-		GenerateEthAddr:     generateEthAddr,
+		SendGas:                       sendGas,
+		ClaimPRL:                      claimPRLs,
+		ClaimUnusedPRLs:               claimUnusedPRLs,
+		GenerateEthAddr:               generateEthAddr,
+		GenerateEthAddrFromPrivateKey: generateEthAddrFromPrivateKey,
 		BuryPrl:             buryPrl,
 		SendETH:             sendETH,
 		SendPRL:             sendPRL,
@@ -140,6 +145,26 @@ func generateEthAddr() (addr common.Address, privateKey string, err error) {
 	addr = crypto.PubkeyToAddress(ethAccount.PublicKey)
 	privateKey = hex.EncodeToString(ethAccount.D.Bytes())
 	return addr, privateKey, err
+}
+
+// Generate an Ethereum address from a private key
+func generateEthAddrFromPrivateKey(privateKey string) (addr common.Address, err error) {
+	if privateKey[0:2] != "0x" && privateKey[0:2] != "0X" {
+		privateKey = "0x" + privateKey
+	}
+	privateKeyBigInt := hexutil.MustDecodeBig(privateKey)
+	ethAccount, err := generatePublicKeyFromPrivateKey(crypto.S256(), privateKeyBigInt)
+	addr = crypto.PubkeyToAddress(ethAccount.PublicKey)
+	return addr, err
+}
+
+// GenerateKey generates a public and private key pair.
+func generatePublicKeyFromPrivateKey(c elliptic.Curve, k *big.Int) (*ecdsa.PrivateKey, error) {
+	privateKey := new(ecdsa.PrivateKey)
+	privateKey.PublicKey.Curve = c
+	privateKey.D = k
+	privateKey.PublicKey.X, privateKey.PublicKey.Y = c.ScalarBaseMult(k.Bytes())
+	return privateKey, nil
 }
 
 // returns represents the 20 byte address of an ethereum account.

--- a/services/eth_gateway_test.go
+++ b/services/eth_gateway_test.go
@@ -65,10 +65,7 @@ func Test_generateEthAddrFromPrivateKey(t *testing.T) {
 		t.Fatalf("error creating ethereum network address")
 	}
 
-	generatedAddress, err := services.EthWrapper.GenerateEthAddrFromPrivateKey(originalPrivateKey)
-	if err != nil {
-		t.Fatalf("error generating eth address from private key: %v\n", err)
-	}
+	generatedAddress := services.EthWrapper.GenerateEthAddrFromPrivateKey(originalPrivateKey)
 
 	// ensure address is what we expected
 	if originalAddr != generatedAddress {

--- a/services/eth_gateway_test.go
+++ b/services/eth_gateway_test.go
@@ -3,22 +3,22 @@ package services_test
 import (
 	"testing"
 
-	"github.com/ethereum/go-ethereum/crypto"
+	"fmt"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
-	"github.com/oysterprotocol/brokernode/services"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/oysterprotocol/brokernode/models"
+	"github.com/oysterprotocol/brokernode/services"
 	"github.com/stretchr/testify/suite"
 	"math/big"
-	"github.com/ethereum/go-ethereum/ethclient"
-	"github.com/ethereum/go-ethereum/core/types"
-	"fmt"
-	"github.com/oysterprotocol/brokernode/models"
 )
 
 // Ethereum Test Suite
 type EthereumTestSuite struct {
 	suite.Suite
-	gateway *services.Eth
+	gateway   *services.Eth
 	ethClient *ethclient.Client // used for testing
 }
 
@@ -41,8 +41,8 @@ func (s *EthereumTestSuite) tearDownSuite() {
 func (s *EthereumTestSuite) generateAddress(t *testing.T) {
 
 	// generate eth address using gateway
-	addr, privateKey, error := s.gateway.GenerateEthAddr()
-	if error != nil {
+	addr, privateKey, err := s.gateway.GenerateEthAddr()
+	if err != nil {
 		t.Fatalf("error creating ethereum network address")
 	}
 	// ensure address is correct format
@@ -56,18 +56,38 @@ func (s *EthereumTestSuite) generateAddress(t *testing.T) {
 	t.Logf("ethereum network address was generated %v\n", addr.Hex())
 }
 
+// generate address from private key test
+func Test_generateEthAddrFromPrivateKey(t *testing.T) {
+
+	// generate eth address using gateway
+	originalAddr, originalPrivateKey, err := services.EthWrapper.GenerateEthAddr()
+	if err != nil {
+		t.Fatalf("error creating ethereum network address")
+	}
+
+	generatedAddress, err := services.EthWrapper.GenerateEthAddrFromPrivateKey(originalPrivateKey)
+	if err != nil {
+		t.Fatalf("error generating eth address from private key: %v\n", err)
+	}
+
+	// ensure address is what we expected
+	if originalAddr != generatedAddress {
+		t.Fatalf("generated address was %s but we expected %s", generatedAddress, originalAddr)
+	}
+}
+
 // get gas price from network test
 func (s *EthereumTestSuite) getGasPrice(t *testing.T) {
 
 	// get the suggested gas price
-	gasPrice, error := s.gateway.GetGasPrice()
-	if error != nil {
-		t.Fatalf("error retrieving gas price: %v\n",error)
+	gasPrice, err := s.gateway.GetGasPrice()
+	if err != nil {
+		t.Fatalf("error retrieving gas price: %v\n", err)
 	}
 	if s.Assert().NotNil(gasPrice) && gasPrice.Uint64() > 0 {
-		t.Logf("gas price verified: %v\n",gasPrice)
+		t.Logf("gas price verified: %v\n", gasPrice)
 	} else {
-		t.Fatalf("gas price less than zero: %v\n",gasPrice)
+		t.Fatalf("gas price less than zero: %v\n", gasPrice)
 	}
 }
 
@@ -83,20 +103,20 @@ func (s *EthereumTestSuite) checkBalance(t *testing.T) {
 	// Convert string address to byte[] address form
 	bal := s.gateway.CheckBalance(auth.From)
 	if bal.Uint64() > 0 {
-		t.Logf("balance verified: %v\n",bal)
+		t.Logf("balance verified: %v\n", bal)
 	} else {
-		t.Fatalf("balance less than zero: %v\n",bal)
+		t.Fatalf("balance less than zero: %v\n", bal)
 	}
 }
 
 func (s *EthereumTestSuite) getCurrentBlock(t *testing.T) {
 	// Get the current block from the network
-	block, error := services.EthWrapper.GetCurrentBlock()
-	if error != nil {
-		t.Fatalf("could not retrieve the current block: %v\n",error)
+	block, err := services.EthWrapper.GetCurrentBlock()
+	if err != nil {
+		t.Fatalf("could not retrieve the current block: %v\n", err)
 	}
 	if block != nil {
-		t.Logf("retrieved the current block: %v\n",block)
+		t.Logf("retrieved the current block: %v\n", block)
 	}
 }
 
@@ -111,7 +131,6 @@ func (s *EthereumTestSuite) sendEther(t *testing.T) {
 	// Send Ether to an Account
 	// WIP - Add once we update the send via contract method
 }
-
 
 //
 // Oyster Pearl Contract Tests
@@ -130,13 +149,13 @@ func (s *EthereumTestSuite) buryPRL(t *testing.T) {
 
 	// prepare oyster message call
 	var msg = services.OysterCallMsg{
-		From: common.HexToAddress("0x0d1d4e623d10f9fba5db95830f7d3839406c6af2"),
-		To: common.HexToAddress("0xf17f52151ebef6c7334fad080c5704d77216b732"),
-		Amount: *big.NewInt(1000),
-		Gas: big.NewInt(10000).Uint64(),
+		From:     common.HexToAddress("0x0d1d4e623d10f9fba5db95830f7d3839406c6af2"),
+		To:       common.HexToAddress("0xf17f52151ebef6c7334fad080c5704d77216b732"),
+		Amount:   *big.NewInt(1000),
+		Gas:      big.NewInt(10000).Uint64(),
 		GasPrice: *big.NewInt(1000),
 		TotalWei: *big.NewInt(100000),
-		Data: []byte(""), // setup data
+		Data:     []byte(""), // setup data
 	}
 
 	// Bury PRL
@@ -155,23 +174,23 @@ func (s *EthereumTestSuite) sendPRL(t *testing.T) {
 
 	// prepare oyster message call
 	var msg = services.OysterCallMsg{
-		From: common.HexToAddress("0x0d1d4e623d10f9fba5db95830f7d3839406c6af2"),
-		To: common.HexToAddress("0xf17f52151ebef6c7334fad080c5704d77216b732"),
-		Amount: *big.NewInt(1000),
-		Gas: big.NewInt(10000).Uint64(),
+		From:     common.HexToAddress("0x0d1d4e623d10f9fba5db95830f7d3839406c6af2"),
+		To:       common.HexToAddress("0xf17f52151ebef6c7334fad080c5704d77216b732"),
+		Amount:   *big.NewInt(1000),
+		Gas:      big.NewInt(10000).Uint64(),
 		GasPrice: *big.NewInt(1000),
 		TotalWei: *big.NewInt(100000),
-		Data: []byte(""), // setup data // TODO finalize by adding contract call to
+		Data:     []byte(""), // setup data // TODO finalize by adding contract call to
 	}
 
 	// Send PRL
 	var sent = s.gateway.SendPRL(msg)
 	if sent {
 		// successful prl send
-		t.Logf("Sent PRL to :%v",msg.From.Hex())
+		t.Logf("Sent PRL to :%v", msg.From.Hex())
 	} else {
 		// failed prl send
-		t.Fatalf("Failed to send PRL to:%v",msg.From.Hex())
+		t.Fatalf("Failed to send PRL to:%v", msg.From.Hex())
 	}
 }
 
@@ -220,7 +239,6 @@ func (s *EthereumTestSuite) claimUnusedPRL(t *testing.T) {
 
 }
 
-
 // subscribe to transfer
 func (s *EthereumTestSuite) subscribeToTransfer(t *testing.T) {
 
@@ -230,7 +248,5 @@ func (s *EthereumTestSuite) subscribeToTransfer(t *testing.T) {
 	channel := make(chan types.Log)
 	s.gateway.SubscribeToTransfer(broker, channel)
 
-	fmt.Printf("Subscribed to :%v",<-channel)
+	fmt.Printf("Subscribed to :%v", <-channel)
 }
-
-

--- a/utils/cryptography.go
+++ b/utils/cryptography.go
@@ -37,8 +37,6 @@ func Decrypt(key string, cipherText string, nonce string) []byte {
 	panicOnErr(err)
 	data, err = gcm.Open(nil, nonceInBytes, data, nil)
 	if err != nil {
-		fmt.Println(err)
-		raven.CaptureError(err, nil)
 		return nil
 	}
 	return data


### PR DESCRIPTION
-add method to eth_gateway to generate an address from a private key
-updates treasures.go and treasures_test.go to reflect that we no longer need to send the ethAddr from the webnode
-removes handling of an error that really isn't an error