### PR TITLE
Hex cannot have a leading 0

### DIFF
--- a/services/eth_gateway.go
+++ b/services/eth_gateway.go
@@ -140,6 +140,9 @@ func generateEthAddr() (addr common.Address, privateKey string, err error) {
 	ethAccount, _ := crypto.GenerateKey()
 	addr = crypto.PubkeyToAddress(ethAccount.PublicKey)
 	privateKey = hex.EncodeToString(ethAccount.D.Bytes())
+	if privateKey[0] == '0' {
+		return generateEthAddr()
+	}
 	return addr, privateKey, err
 }
 


### PR DESCRIPTION
I got this error recently:  

```
--- FAIL: Test_generateEthAddrFromPrivateKey (0.00s)
panic: hex number with leading zero digits [recovered]
       panic: hex number with leading zero digits

goroutine 70 [running]:
testing.tRunner.func1(0xc4203540f0)
       /usr/local/go/src/testing/testing.go:742 +0x29d
panic(0xa3d560, 0x1116d50)
       /usr/local/go/src/runtime/panic.go:502 +0x229
github.com/ethereum/go-ethereum/common/hexutil.MustDecodeBig(0xc42021e5a0, 0x42, 0x2)
       /go/src/github.com/ethereum/go-ethereum/common/hexutil/hexutil.go:172 +0x6f
github.com/oysterprotocol/brokernode/services.generateEthAddrFromPrivateKey(0xc420028700, 0x40, 0x0, 0x0, 0x0)
       /go/src/github.com/oysterprotocol/brokernode/services/eth_gateway.go:155 +0x65
github.com/oysterprotocol/brokernode/services_test.Test_generateEthAddrFromPrivateKey(0xc4203540f0)
       /go/src/github.com/oysterprotocol/brokernode/services/eth_gateway_test.go:68 +0x9b
testing.tRunner(0xc4203540f0, 0xba0ec0)
       /usr/local/go/src/testing/testing.go:777 +0xd0
created by testing.(*T).Run
       /usr/local/go/src/testing/testing.go:824 +0x2e0
FAIL    github.com/oysterprotocol/brokernode/services   0.054s
ok      github.com/oysterprotocol/brokernode/utils      (cached)
```

This is to fix that.  If we generate a private key with a leading 0, generate a new one.  