### PR TITLE
Encrypt Eth Keys instead of storing naked keys

### DIFF
--- a/actions/upload_sessions.go
+++ b/actions/upload_sessions.go
@@ -155,7 +155,13 @@ func (usr *UploadSessionResource) Create(c buffalo.Context) error {
 		fmt.Println(err)
 	}
 
-	privateKeys := services.EthWrapper.GenerateKeys(len(mergedIndexes))
+	privateKeys, err := services.EthWrapper.GenerateKeys(len(mergedIndexes))
+	if err != nil {
+		err := errors.New("Could not generate eth keys: " + err.Error())
+		fmt.Println(err)
+		c.Error(400, err)
+		return err
+	}
 	if len(mergedIndexes) != len(privateKeys) {
 		err := errors.New("privateKeys and mergedIndexes should have the same length")
 		raven.CaptureError(err, nil)
@@ -207,6 +213,7 @@ func (usr *UploadSessionResource) Update(c buffalo.Context) error {
 	}
 	if uploadSession == nil {
 		err := errors.New("Error finding sessions")
+		raven.CaptureError(err, nil)
 		c.Error(400, err)
 		return err
 	}
@@ -362,7 +369,13 @@ func (usr *UploadSessionResource) CreateBeta(c buffalo.Context) error {
 		c.Error(400, err)
 		return err
 	}
-	privateKeys := services.EthWrapper.GenerateKeys(len(mergedIndexes))
+	privateKeys, err := services.EthWrapper.GenerateKeys(len(mergedIndexes))
+	if err != nil {
+		err := errors.New("Could not generate eth keys: " + err.Error())
+		fmt.Println(err)
+		c.Error(400, err)
+		return err
+	}
 	if len(mergedIndexes) != len(privateKeys) {
 		err := errors.New("privateKeys and mergedIndexes should have the same length")
 		raven.CaptureError(err, nil)
@@ -393,7 +406,9 @@ func (usr *UploadSessionResource) GetPaymentStatus(c buffalo.Context) error {
 		return err
 	}
 	if (session == models.UploadSession{}) {
-		c.Error(400, errors.New("Did not find session that matched id"))
+		err := errors.New("Did not find session that matched id" + c.Param("id"))
+		raven.CaptureError(err, nil)
+		c.Error(400, err)
 		return err
 	}
 

--- a/jobs/claim_unused_prls_test.go
+++ b/jobs/claim_unused_prls_test.go
@@ -1,6 +1,7 @@
 package jobs_test
 
 import (
+	"encoding/hex"
 	"github.com/oysterprotocol/brokernode/jobs"
 	"github.com/oysterprotocol/brokernode/models"
 	"github.com/oysterprotocol/brokernode/services"
@@ -190,49 +191,49 @@ func testSetup(suite *JobsSuite) {
 	RowWithGasTransferNotStarted = models.CompletedUpload{
 		GenesisHash:   "RowWithGasTransferNotStarted",
 		ETHAddr:       "SOME_ETH_ADDR_RowWithGasTransferNotStarted",
-		ETHPrivateKey: "SOME_PRIVATE_KEY_RowWithGasTransferNotStarted",
+		ETHPrivateKey: hex.EncodeToString([]byte("SOME_PRIVATE_KEY_RowWithGasTransferNotStarted")),
 		PRLStatus:     models.PRLClaimNotStarted,
 		GasStatus:     models.GasTransferNotStarted,
 	}
 	RowWithGasTransferProcessing = models.CompletedUpload{
 		GenesisHash:   "RowWithGasTransferProcessing",
 		ETHAddr:       "SOME_ETH_ADDR_RowWithGasTransferProcessing",
-		ETHPrivateKey: "SOME_PRIVATE_KEY_RowWithGasTransferProcessing",
+		ETHPrivateKey: hex.EncodeToString([]byte("SOME_PRIVATE_KEY_RowWithGasTransferProcessing")),
 		PRLStatus:     models.PRLClaimNotStarted,
 		GasStatus:     models.GasTransferProcessing,
 	}
 	RowWithGasTransferSuccess = models.CompletedUpload{
 		GenesisHash:   "RowWithGasTransferSuccess",
 		ETHAddr:       "SOME_ETH_ADDR_RowWithGasTransferSuccess",
-		ETHPrivateKey: "SOME_PRIVATE_KEY_RowWithGasTransferSuccess",
+		ETHPrivateKey: hex.EncodeToString([]byte("SOME_PRIVATE_KEY_RowWithGasTransferSuccess")),
 		PRLStatus:     models.PRLClaimNotStarted,
 		GasStatus:     models.GasTransferSuccess,
 	}
 	RowWithGasTransferError = models.CompletedUpload{
 		GenesisHash:   "RowWithGasTransferError",
 		ETHAddr:       "SOME_ETH_ADDR_RowWithGasTransferError",
-		ETHPrivateKey: "SOME_PRIVATE_KEY_RowWithGasTransferError",
+		ETHPrivateKey: hex.EncodeToString([]byte("SOME_PRIVATE_KEY_RowWithGasTransferError")),
 		PRLStatus:     models.PRLClaimNotStarted,
 		GasStatus:     models.GasTransferError,
 	}
 	RowWithPRLClaimProcessing = models.CompletedUpload{
 		GenesisHash:   "RowWithPRLClaimProcessing",
 		ETHAddr:       "SOME_ETH_ADDR_RowWithPRLClaimProcessing",
-		ETHPrivateKey: "SOME_PRIVATE_KEY_RowWithPRLClaimProcessing",
+		ETHPrivateKey: hex.EncodeToString([]byte("SOME_PRIVATE_KEY_RowWithPRLClaimProcessing")),
 		PRLStatus:     models.PRLClaimProcessing,
 		GasStatus:     models.GasTransferSuccess,
 	}
 	RowWithPRLClaimSuccess = models.CompletedUpload{
 		GenesisHash:   "RowWithPRLClaimSuccess",
 		ETHAddr:       "SOME_ETH_ADDR_RowWithPRLClaimSuccess",
-		ETHPrivateKey: "SOME_PRIVATE_KEY_RowWithPRLClaimSuccess",
+		ETHPrivateKey: hex.EncodeToString([]byte("SOME_PRIVATE_KEY_RowWithPRLClaimSuccess")),
 		PRLStatus:     models.PRLClaimSuccess,
 		GasStatus:     models.GasTransferSuccess,
 	}
 	RowWithPRLClaimError = models.CompletedUpload{
 		GenesisHash:   "RowWithPRLClaimError",
 		ETHAddr:       "SOME_ETH_ADDR_RowWithPRLClaimError",
-		ETHPrivateKey: "SOME_PRIVATE_KEY_RowWithPRLClaimError",
+		ETHPrivateKey: hex.EncodeToString([]byte("SOME_PRIVATE_KEY_RowWithPRLClaimError")),
 		PRLStatus:     models.PRLClaimError,
 		GasStatus:     models.GasTransferSuccess,
 	}

--- a/jobs/process_paid_sessions_test.go
+++ b/jobs/process_paid_sessions_test.go
@@ -1,7 +1,6 @@
 package jobs_test
 
 import (
-	"fmt"
 	"github.com/gobuffalo/pop/nulls"
 	"github.com/oysterprotocol/brokernode/jobs"
 	"github.com/oysterprotocol/brokernode/models"
@@ -16,24 +15,6 @@ func (suite *JobsSuite) Test_ProcessPaidSessions() {
 	treasureIndexes[5] = 5
 	treasureIndexes[78] = 78
 	treasureIndexes[199] = 199
-
-	// create a dummy TreasureIdxMap for the data maps
-	// that need to get treasure buried
-	testMap1 := `[{
-		"sector": 1,
-		"idx": ` + fmt.Sprint(treasureIndexes[5]) + `,
-		"key": "0000000001"
-		},
-		{
-		"sector": 2,
-		"idx": ` + fmt.Sprint(treasureIndexes[78]) + `,
-		"key": "0000000002"
-		},
-		{
-		"sector": 3,
-		"idx": ` + fmt.Sprint(treasureIndexes[199]) + `,
-		"key": "0000000003"
-		}]`
 
 	// create another dummy TreasureIdxMap for the data maps
 	// who already have treasure buried
@@ -61,10 +42,13 @@ func (suite *JobsSuite) Test_ProcessPaidSessions() {
 		Type:           models.SessionTypeAlpha,
 		PaymentStatus:  models.PaymentStatusConfirmed,
 		TreasureStatus: models.TreasureBurying,
-		TreasureIdxMap: nulls.String{string(testMap1), true},
 	}
 
 	uploadSession1.StartUploadSession()
+	mergedIndexes := []int{treasureIndexes[5], treasureIndexes[78], treasureIndexes[199]}
+	privateKeys := []string{"0000000001", "0000000002", "0000000003"}
+
+	uploadSession1.MakeTreasureIdxMap(mergedIndexes, privateKeys)
 
 	// create and start the upload session for the data maps that already have buried treasure
 	uploadSession2 := models.UploadSession{

--- a/jobs/purge_completed_sessions_test.go
+++ b/jobs/purge_completed_sessions_test.go
@@ -1,6 +1,7 @@
 package jobs_test
 
 import (
+	"encoding/hex"
 	"github.com/gobuffalo/pop/nulls"
 	"github.com/oysterprotocol/brokernode/jobs"
 	"github.com/oysterprotocol/brokernode/models"
@@ -17,7 +18,7 @@ func (suite *JobsSuite) Test_PurgeCompletedSessions() {
 		Type:          models.SessionTypeBeta,
 		ETHAddrAlpha:  nulls.String{string("SOME_ALPHA_ETH_ADDRESS"), true},
 		ETHAddrBeta:   nulls.String{string("SOME_BETA_ETH_ADDRESS"), true},
-		ETHPrivateKey: "SOME_PRIVATE_KEY",
+		ETHPrivateKey: hex.EncodeToString([]byte("SOME_PRIVATE_KEY")),
 	}
 
 	vErr, err := uploadSession1.StartUploadSession()
@@ -138,6 +139,5 @@ func (suite *JobsSuite) Test_PurgeCompletedSessions() {
 	suite.Equal(nil, err)
 
 	suite.Equal("SOME_BETA_ETH_ADDRESS", completedUploads[0].ETHAddr)
-	suite.Equal("SOME_PRIVATE_KEY", completedUploads[0].ETHPrivateKey)
 	suite.Equal("genHash1", completedUploads[0].GenesisHash)
 }

--- a/models/upload_sessions.go
+++ b/models/upload_sessions.go
@@ -267,15 +267,16 @@ func (u *UploadSession) MakeTreasureIdxMap(mergedIndexes []int, privateKeys []st
 			return
 		}
 
-		hashedSessionID := oyster_utils.HashString(fmt.Sprint(u.ID), sha3.New256())
-		hashedChunkCreationTime := oyster_utils.HashString(fmt.Sprint(treasureChunks[0].CreatedAt), sha3.New256())
-
-		encryptedKey := oyster_utils.Encrypt(hashedSessionID, privateKeys[i], hashedChunkCreationTime)
+		encryptedKey, err := treasureChunks[0].EncryptEthKey(privateKeys[i])
+		if err != nil {
+			fmt.Println(err)
+			return
+		}
 
 		treasureIndexArray = append(treasureIndexArray, TreasureMap{
 			Sector: i,
 			Idx:    mergedIndex,
-			Key:    hex.EncodeToString(encryptedKey),
+			Key:    encryptedKey,
 		})
 	}
 

--- a/models/upload_sessions.go
+++ b/models/upload_sessions.go
@@ -1,11 +1,13 @@
 package models
 
 import (
+	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"github.com/oysterprotocol/brokernode/utils"
+	"golang.org/x/crypto/sha3"
 	"math"
-	"os"
 	"time"
 
 	"github.com/getsentry/raven-go"
@@ -173,6 +175,8 @@ func (u *UploadSession) StartUploadSession() (vErr *validate.Errors, err error) 
 		return
 	}
 
+	u.EncryptSessionEthKey()
+
 	vErr, err = BuildDataMaps(u.GenesisHash, u.NumChunks)
 	return
 }
@@ -246,21 +250,32 @@ func (u *UploadSession) SetTreasureMap(treasureIndexMap []TreasureMap) error {
 }
 
 // Sets the TreasureIdxMap with Sector, Idx, and Key
-func (u *UploadSession) MakeTreasureIdxMap(alphaIndexes []int, betaIndexs []int) {
-	mergedIndexes, err := oyster_utils.MergeIndexes(alphaIndexes, betaIndexs)
+func (u *UploadSession) MakeTreasureIdxMap(mergedIndexes []int, privateKeys []string) {
+
 	treasureIndexArray := make([]TreasureMap, 0)
 
-	key := ""
-
-	if oyster_utils.BrokerMode == oyster_utils.TestModeDummyTreasure {
-		key = os.Getenv("TEST_MODE_WALLET_KEY")
-	}
-
 	for i, mergedIndex := range mergedIndexes {
+		treasureChunks, err := GetDataMapByGenesisHashAndChunkIdx(u.GenesisHash, mergedIndex)
+		if err != nil {
+			fmt.Println(err)
+			return
+		}
+		if len(treasureChunks) == 0 || len(treasureChunks) > 1 {
+			err = errors.New("did not find a chunk that matched genesis_hash and chunk_idx in MakeTreasureIdxMap, or " +
+				"found duplicate chunks")
+			raven.CaptureError(err, nil)
+			return
+		}
+
+		hashedSessionID := oyster_utils.HashString(fmt.Sprint(u.ID), sha3.New256())
+		hashedChunkCreationTime := oyster_utils.HashString(fmt.Sprint(treasureChunks[0].CreatedAt), sha3.New256())
+
+		encryptedKey := oyster_utils.Encrypt(hashedSessionID, privateKeys[i], hashedChunkCreationTime)
+
 		treasureIndexArray = append(treasureIndexArray, TreasureMap{
 			Sector: i,
 			Idx:    mergedIndex,
-			Key:    key, // TODO where are we getting the real keys?
+			Key:    hex.EncodeToString(encryptedKey),
 		})
 	}
 
@@ -315,6 +330,25 @@ func (u *UploadSession) GetPaymentStatus() string {
 	default:
 		return "error"
 	}
+}
+
+func (u *UploadSession) EncryptSessionEthKey() {
+	hashedSessionID := oyster_utils.HashString(fmt.Sprint(u.ID), sha3.New256())
+	hashedCreationTime := oyster_utils.HashString(fmt.Sprint(u.CreatedAt), sha3.New256())
+
+	encryptedKey := oyster_utils.Encrypt(hashedSessionID, u.ETHPrivateKey, hashedCreationTime)
+
+	u.ETHPrivateKey = hex.EncodeToString(encryptedKey)
+	DB.ValidateAndSave(u)
+}
+
+func (u *UploadSession) DecryptSessionEthKey() string {
+	hashedSessionID := oyster_utils.HashString(fmt.Sprint(u.ID), sha3.New256())
+	hashedCreationTime := oyster_utils.HashString(fmt.Sprint(u.CreatedAt), sha3.New256())
+
+	decryptedKey := oyster_utils.Decrypt(hashedSessionID, u.ETHPrivateKey, hashedCreationTime)
+
+	return hex.EncodeToString(decryptedKey)
 }
 
 func GetSessionsByAge() ([]UploadSession, error) {

--- a/models/upload_sessions_test.go
+++ b/models/upload_sessions_test.go
@@ -283,7 +283,8 @@ func (ms *ModelSuite) Test_GetTreasureIndexes() {
 
 	mergedIndexes, err := oyster_utils.MergeIndexes(alphaIndexes, betaIndexes)
 	ms.Nil(err)
-	privateKeys := services.EthWrapper.GenerateKeys(len(mergedIndexes))
+	privateKeys, err := services.EthWrapper.GenerateKeys(len(mergedIndexes))
+	ms.Nil(err)
 	u.MakeTreasureIdxMap(mergedIndexes, privateKeys)
 	actualIndexes, err := u.GetTreasureIndexes()
 

--- a/services/eth_gateway.go
+++ b/services/eth_gateway.go
@@ -6,6 +6,7 @@ import (
 	"crypto/elliptic"
 	"encoding/hex"
 	"fmt"
+	"github.com/oysterprotocol/brokernode/utils"
 	"log"
 	"math/big"
 	"os"
@@ -32,6 +33,7 @@ type Eth struct {
 	ClaimPRL
 	ClaimUnusedPRLs
 	GenerateEthAddr
+	GenerateKeys
 	GenerateEthAddrFromPrivateKey
 	BuryPrl
 	SendETH
@@ -56,6 +58,7 @@ type OysterCallMsg struct {
 
 type SendGas func([]models.CompletedUpload) error
 type GenerateEthAddr func() (addr common.Address, privateKey string, err error)
+type GenerateKeys func(int) (privateKeys []string)
 type GenerateEthAddrFromPrivateKey func(privateKey string) (addr common.Address)
 type GetGasPrice func() (*big.Int, error)
 type WaitForTransfer func(brokerAddr common.Address) (bool, error)
@@ -100,6 +103,7 @@ func init() {
 		ClaimPRL:                      claimPRLs,
 		ClaimUnusedPRLs:               claimUnusedPRLs,
 		GenerateEthAddr:               generateEthAddr,
+		GenerateKeys:                  generateKeys,
 		GenerateEthAddrFromPrivateKey: generateEthAddrFromPrivateKey,
 		BuryPrl:         buryPrl,
 		SendETH:         sendETH,
@@ -141,6 +145,21 @@ func generateEthAddr() (addr common.Address, privateKey string, err error) {
 	addr = crypto.PubkeyToAddress(ethAccount.PublicKey)
 	privateKey = hex.EncodeToString(ethAccount.D.Bytes())
 	return addr, privateKey, err
+}
+
+// Generate an array of eth keys
+func generateKeys(numKeys int) []string {
+	var keys []string
+	for i := 0; i < numKeys; i++ {
+		key := ""
+		if oyster_utils.BrokerMode == oyster_utils.TestModeDummyTreasure {
+			key = os.Getenv("TEST_MODE_WALLET_KEY")
+		} else {
+			_, key, _ = generateEthAddr()
+		}
+		keys = append(keys, key)
+	}
+	return keys
 }
 
 // Generate an Ethereum address from a private key


### PR DESCRIPTION
-encrypts the eth keys so we aren't just storing them naked in the dbs.  
-for keys and nonces, I'm using hashes of the session ID and hashes of the CreatedAt time for sessions (if encrypting an ethKey for a session) or for chunks (if encrypting eth keys for treasures)
-buffalo suggests using c.Error instead of c.Render for errors

FYI, this PR means that we'll have to decrypt the eth key of the session to be able to use it for transactions.  But there's a method for that.  