### PR TITLE
Allow more CORs methods so people don't have to install chrome extens…

### DIFF
--- a/actions/app.go
+++ b/actions/app.go
@@ -30,7 +30,7 @@ func App() *buffalo.App {
 			LooseSlash:   true,
 			SessionStore: sessions.Null{},
 			PreWares: []buffalo.PreWare{
-				cors.Default().Handler,
+				cors.AllowAll().Handler,
 			},
 			SessionName: "_brokernode_session",
 			WorkerOff:   false,


### PR DESCRIPTION
…ion to hack this. The default before was to not allow PUTs https://github.com/rs/cors/blob/master/cors.go#L32