### PR TITLE
Move EthWrapper/IotaWrapper into app.go

### DIFF
--- a/actions/actions_test.go
+++ b/actions/actions_test.go
@@ -1,14 +1,22 @@
 package actions
 
 import (
-	"github.com/oysterprotocol/brokernode/utils"
 	"testing"
 
 	"github.com/gobuffalo/suite"
+	"github.com/oysterprotocol/brokernode/services"
+	"github.com/oysterprotocol/brokernode/utils"
 )
 
 type ActionSuite struct {
 	*suite.Action
+}
+
+func (suite *ActionSuite) SetupTest() {
+	suite.Action.SetupTest()
+
+	EthWrapper = services.EthWrapper
+	IotaWrapper = services.IotaWrapper
 }
 
 func Test_ActionSuite(t *testing.T) {

--- a/actions/app.go
+++ b/actions/app.go
@@ -11,6 +11,7 @@ import (
 	"github.com/gobuffalo/x/sessions"
 	"github.com/oysterprotocol/brokernode/jobs"
 	"github.com/oysterprotocol/brokernode/models"
+	"github.com/oysterprotocol/brokernode/services"
 	"github.com/rs/cors"
 	"github.com/unrolled/secure"
 )
@@ -19,6 +20,10 @@ import (
 // application is being run. Default is "development".
 var ENV = envy.Get("GO_ENV", "development")
 var app *buffalo.App
+
+// Visible for Unit Test
+var IotaWrapper = services.IotaWrapper
+var EthWrapper = services.EthWrapper
 
 // App is where all routes and middleware for buffalo
 // should be defined. This is the nerve center of your

--- a/actions/treasures.go
+++ b/actions/treasures.go
@@ -23,10 +23,6 @@ type treasureRes struct {
 	Success bool `json:"success"`
 }
 
-// Visible for Unit Test
-var IotaWrapper = services.IotaWrapper
-var EthWrapper = services.EthWrapper
-
 // Verifies the treasure and claims such treasure.
 func (t *TreasuresResource) VerifyAndClaim(c buffalo.Context) error {
 	req := treasureReq{}

--- a/actions/upload_sessions.go
+++ b/actions/upload_sessions.go
@@ -76,7 +76,7 @@ func (usr *UploadSessionResource) Create(c buffalo.Context) error {
 	req := uploadSessionCreateReq{}
 	oyster_utils.ParseReqBody(c.Request(), &req)
 
-	alphaEthAddr, privKey, _ := services.EthWrapper.GenerateEthAddr()
+	alphaEthAddr, privKey, _ := EthWrapper.GenerateEthAddr()
 
 	// Start Alpha Session.
 	alphaSession := models.UploadSession{
@@ -156,7 +156,7 @@ func (usr *UploadSessionResource) Create(c buffalo.Context) error {
 		fmt.Println(err)
 	}
 
-	privateKeys, err := services.EthWrapper.GenerateKeys(len(mergedIndexes))
+	privateKeys, err := EthWrapper.GenerateKeys(len(mergedIndexes))
 	if err != nil {
 		err := errors.New("Could not generate eth keys: " + err.Error())
 		fmt.Println(err)
@@ -332,7 +332,7 @@ func (usr *UploadSessionResource) CreateBeta(c buffalo.Context) error {
 	betaTreasureIndexes := oyster_utils.GenerateInsertedIndexesForPearl(oyster_utils.ConvertToByte(req.FileSizeBytes))
 
 	// Generates ETH address.
-	betaEthAddr, privKey, _ := services.EthWrapper.GenerateEthAddr()
+	betaEthAddr, privKey, _ := EthWrapper.GenerateEthAddr()
 
 	u := models.UploadSession{
 		Type:                 models.SessionTypeBeta,
@@ -371,7 +371,7 @@ func (usr *UploadSessionResource) CreateBeta(c buffalo.Context) error {
 		c.Error(400, err)
 		return err
 	}
-	privateKeys, err := services.EthWrapper.GenerateKeys(len(mergedIndexes))
+	privateKeys, err := EthWrapper.GenerateKeys(len(mergedIndexes))
 	if err != nil {
 		err := errors.New("Could not generate eth keys: " + err.Error())
 		fmt.Println(err)
@@ -434,7 +434,7 @@ func waitForTransferAndNotifyBeta(alphaEthAddr string, betaEthAddr string, uploa
 	}
 
 	transferAddr := services.StringToAddress(alphaEthAddr)
-	balance, err := services.EthWrapper.WaitForTransfer(transferAddr)
+	balance, err := EthWrapper.WaitForTransfer(transferAddr)
 
 	paymentStatus := models.PaymentStatusConfirmed
 	if err != nil {
@@ -463,6 +463,6 @@ func waitForTransferAndNotifyBeta(alphaEthAddr string, betaEthAddr string, uploa
 			To:     services.StringToAddress(betaEthAddr),
 			Amount: splitAmount,
 		}
-		services.EthWrapper.SendPRL(callMsg)
+		EthWrapper.SendPRL(callMsg)
 	}
 }


### PR DESCRIPTION
Inside package actions, everyone had to share EthWrapper/IotaWrapper. Unfortunately, this is hard to change. As a result, move it to app.go.

Since every test in the same package is run sequentially. We need to reset EthWrapper/IotaWrapper for each test.