### PR TITLE
Clean up job_runner directory

### DIFF
--- a/jobs/claim_unused_prls.go
+++ b/jobs/claim_unused_prls.go
@@ -3,23 +3,15 @@ package jobs
 import (
 	"github.com/getsentry/raven-go"
 	"github.com/oysterprotocol/brokernode/models"
-	"github.com/oysterprotocol/brokernode/services"
 	"github.com/oysterprotocol/brokernode/utils"
 	"gopkg.in/segmentio/analytics-go.v3"
 	"log"
 	"time"
 )
 
-var ethWrapper = services.EthWrapper
-
-func init() {
-}
-
-func ClaimUnusedPRLs(ethService services.Eth, thresholdTime time.Time) {
+func ClaimUnusedPRLs(thresholdTime time.Time) {
 
 	if oyster_utils.BrokerMode == oyster_utils.ProdMode {
-		SetEthWrapper(ethService)
-
 		ResendTimedOutGasTransfers(thresholdTime)
 		ResendTimedOutPRLTransfers(thresholdTime)
 
@@ -31,10 +23,6 @@ func ClaimUnusedPRLs(ethService services.Eth, thresholdTime time.Time) {
 
 		PurgeCompletedClaims()
 	}
-}
-
-func SetEthWrapper(ethService services.Eth) {
-	ethWrapper = ethService
 }
 
 // for gas transfers that are still processing by the time of the threshold
@@ -160,7 +148,7 @@ func StartNewClaims() {
 
 // wraps calls eth_gatway's SendGas method and sets GasStatus to GasTransferProcessing
 func InitiateGasTransfer(uploadsThatNeedGas []models.CompletedUpload) {
-	err := ethWrapper.SendGas(uploadsThatNeedGas)
+	err := EthWrapper.SendGas(uploadsThatNeedGas)
 	if err != nil {
 		log.Println("Error sending gas.")
 		raven.CaptureError(err, nil)
@@ -172,7 +160,7 @@ func InitiateGasTransfer(uploadsThatNeedGas []models.CompletedUpload) {
 
 // wraps calls eth_gatway's ClaimUnusedPRLs method and sets GasStatus to GasTransferProcessing
 func InitiatePRLClaim(uploadsWithUnclaimedPRLs []models.CompletedUpload) {
-	err := ethWrapper.ClaimUnusedPRLs(uploadsWithUnclaimedPRLs)
+	err := EthWrapper.ClaimUnusedPRLs(uploadsWithUnclaimedPRLs)
 	if err != nil {
 		log.Println("Error claiming PRL.")
 		raven.CaptureError(err, nil)

--- a/jobs/claim_unused_prls_test.go
+++ b/jobs/claim_unused_prls_test.go
@@ -32,7 +32,7 @@ func (suite *JobsSuite) Test_ClaimUnusedPRLs() {
 
 	makeEthMocks_claim_unused_prls(&EthMock)
 
-	jobs.SetEthWrapper(EthMock)
+	jobs.EthWrapper = EthMock
 
 	testSetup(suite)
 

--- a/jobs/job_runner.go
+++ b/jobs/job_runner.go
@@ -126,7 +126,7 @@ func processPaidSessionsHandler(args worker.Args) error {
 
 func claimUnusedPRLsHandler(args worker.Args) error {
 	thresholdTime := time.Now().Add(-3 * time.Hour) // consider a transaction timed out if it takes more than 3 hours
-	ClaimUnusedPRLs(EthWrapper, thresholdTime)
+	ClaimUnusedPRLs(thresholdTime)
 
 	oysterWorkerPerformIn(claimUnusedPRLsHandler, args)
 	return nil

--- a/jobs/job_runner_test.go
+++ b/jobs/job_runner_test.go
@@ -1,12 +1,14 @@
 package jobs_test
 
 import (
+	"testing"
+
 	"github.com/gobuffalo/suite"
 	"github.com/iotaledger/giota"
+	"github.com/oysterprotocol/brokernode/jobs"
 	"github.com/oysterprotocol/brokernode/models"
 	"github.com/oysterprotocol/brokernode/services"
 	"github.com/oysterprotocol/brokernode/utils"
-	"testing"
 )
 
 var IotaMock services.IotaService
@@ -17,7 +19,13 @@ type JobsSuite struct {
 
 var Suite JobsSuite
 
-func (suite *JobsSuite) SetupSuite() {
+func (suite *JobsSuite) SetupTest() {
+	suite.Model.SetupTest()
+
+	// Reset the jobs's IotaWrapper, EthWrapper before each test.
+	// Some tests may override this value.
+	jobs.IotaWrapper = services.IotaWrapper
+	jobs.EthWrapper = services.EthWrapper
 
 	/*
 		This creates a "generic" mock of our iota wrapper. we can assign

--- a/jobs/process_paid_sessions.go
+++ b/jobs/process_paid_sessions.go
@@ -8,11 +8,7 @@ import (
 	"github.com/oysterprotocol/brokernode/services"
 	"github.com/oysterprotocol/brokernode/utils"
 	"gopkg.in/segmentio/analytics-go.v3"
-	"log"
 )
-
-func init() {
-}
 
 func ProcessPaidSessions() {
 
@@ -61,9 +57,8 @@ func BuryTreasure(treasureIndexMap []models.TreasureMap, unburiedSession *models
 		if len(treasureChunks) == 0 || len(treasureChunks) > 1 {
 			errString := "did not find a chunk that matched genesis_hash and chunk_idx in process_paid_sessions, or " +
 				"found duplicate chunks"
-			log.Println(errString)
 			err = errors.New(errString)
-			raven.CaptureError(err, nil)
+			oyster_utils.LogIfError(err)
 			return err
 		}
 
@@ -199,7 +194,7 @@ func sendPRL(treasureToBury models.Treasure) {
 		errorString := "Failure sending " + fmt.Sprint(treasureToBury.GetPRLAmount().Int64()) + " PRL to " +
 			treasureToBury.ETHAddr
 		err := errors.New(errorString)
-		raven.CaptureError(err, nil)
+		oyster_utils.LogIfError(err)
 	} else {
 		treasureToBury.PRLStatus = models.PRLPending
 		models.DB.ValidateAndUpdate(&treasureToBury)
@@ -222,7 +217,7 @@ func sendGas(treasureToBury models.Treasure) {
 		errorString := "Cannot send Gas to treasure address due to insufficient balance in wallet.  balance: " +
 			fmt.Sprint(balance.Int64()) + "; amount_to_send: " + fmt.Sprint(gas.Int64())
 		err := errors.New(errorString)
-		raven.CaptureError(err, nil)
+		oyster_utils.LogIfError(err)
 		return
 	}
 
@@ -230,7 +225,7 @@ func sendGas(treasureToBury models.Treasure) {
 	if err != nil {
 		errorString := "Failure sending " + fmt.Sprint(gas.Int64()) + " Gas to " + treasureToBury.ETHAddr
 		err := errors.New(errorString)
-		raven.CaptureError(err, nil)
+		oyster_utils.LogIfError(err)
 	} else {
 		treasureToBury.PRLStatus = models.GasPending
 		models.DB.ValidateAndUpdate(&treasureToBury)
@@ -254,7 +249,7 @@ func buryPRL(treasureToBury models.Treasure) {
 		errorString := "Cannot bury treasure address due to insufficient balance in treasure wallet.  balance of PRL: " +
 			fmt.Sprint(balanceOfPRL.Int64()) + "; balance of ETH: " + fmt.Sprint(balanceOfETH.Int64())
 		err := errors.New(errorString)
-		raven.CaptureError(err, nil)
+		oyster_utils.LogIfError(err)
 		return
 	}
 
@@ -267,7 +262,7 @@ func buryPRL(treasureToBury models.Treasure) {
 	if !success {
 		errorString := "Failure bury  " + treasureToBury.ETHAddr
 		err := errors.New(errorString)
-		raven.CaptureError(err, nil)
+		oyster_utils.LogIfError(err)
 	} else {
 		treasureToBury.PRLStatus = models.BuryPending
 		models.DB.ValidateAndUpdate(&treasureToBury)

--- a/jobs/process_unassigned_chunks.go
+++ b/jobs/process_unassigned_chunks.go
@@ -12,16 +12,10 @@ import (
 	"time"
 )
 
-func init() {
-}
-
 func ProcessUnassignedChunks(iotaWrapper services.IotaService) {
 
 	sessions, err := models.GetSessionsByAge()
-	if err != nil {
-		fmt.Println(err)
-		raven.CaptureError(err, nil)
-	}
+	oyster_utils.LogIfError(err)
 
 	if len(sessions) > 0 {
 		GetSessionUnassignedChunks(sessions, iotaWrapper)
@@ -31,10 +25,8 @@ func ProcessUnassignedChunks(iotaWrapper services.IotaService) {
 func GetSessionUnassignedChunks(sessions []models.UploadSession, iotaWrapper services.IotaService) {
 	for _, session := range sessions {
 		channels, err := models.GetReadyChannels()
-		if err != nil {
-			fmt.Println(err)
-			raven.CaptureError(err, nil)
-		}
+		oyster_utils.LogIfError(err)
+
 		if len(channels) <= 0 {
 			break
 		}
@@ -97,10 +89,7 @@ func FilterAndAssignChunksToChannels(chunksIn []models.DataMap, channels []model
 
 		chunks, treasureChunksNeedAttaching := HandleTreasureChunks(chunksIn[i:end], session, iotaWrapper)
 		filteredChunks, err := iotaWrapper.VerifyChunkMessagesMatchRecord(chunks)
-		if err != nil {
-			fmt.Println(err)
-			raven.CaptureError(err, nil)
-		}
+		oyster_utils.LogIfError(err)
 
 		if len(filteredChunks.MatchesTangle) > 0 {
 
@@ -272,10 +261,7 @@ func HandleTreasureChunks(chunks []models.DataMap, session models.UploadSession,
 	var treasureChunksToAttach []models.DataMap
 
 	treasureIndexes, err := session.GetTreasureIndexes()
-	if err != nil {
-		fmt.Println(err)
-		raven.CaptureError(err, nil)
-	}
+	oyster_utils.LogIfError(err)
 
 	if len(chunks) == 0 {
 		return chunks, []models.DataMap{}

--- a/jobs/process_unassigned_chunks_test.go
+++ b/jobs/process_unassigned_chunks_test.go
@@ -21,8 +21,8 @@ func (suite *JobsSuite) Test_ProcessUnassignedChunks() {
 
 	numChunks := 31
 
-	// reset back to generic mocks
-	defer suite.SetupSuite()
+	// // reset back to generic mocks
+	// defer suite.SetupSuite()
 
 	// make suite available inside mock methods
 	Suite = *suite
@@ -141,9 +141,6 @@ func (suite *JobsSuite) Test_ProcessUnassignedChunks() {
 func (suite *JobsSuite) Test_HandleTreasureChunks() {
 
 	numChunks := 25
-
-	// reset back to generic mocks
-	defer suite.SetupSuite()
 
 	// make suite available inside mock methods
 	Suite = *suite

--- a/jobs/process_unassigned_chunks_test.go
+++ b/jobs/process_unassigned_chunks_test.go
@@ -21,9 +21,6 @@ func (suite *JobsSuite) Test_ProcessUnassignedChunks() {
 
 	numChunks := 31
 
-	// // reset back to generic mocks
-	// defer suite.SetupSuite()
-
 	// make suite available inside mock methods
 	Suite = *suite
 

--- a/jobs/purge_completed_sessions.go
+++ b/jobs/purge_completed_sessions.go
@@ -1,8 +1,6 @@
 package jobs
 
 import (
-	"fmt"
-	"github.com/getsentry/raven-go"
 	"github.com/gobuffalo/pop"
 	"github.com/oysterprotocol/brokernode/models"
 	"github.com/oysterprotocol/brokernode/utils"
@@ -18,11 +16,7 @@ func PurgeCompletedSessions() {
 	var allGenesisHashesStruct = []models.DataMap{}
 
 	err := models.DB.RawQuery("SELECT distinct genesis_hash FROM data_maps").All(&allGenesisHashesStruct)
-
-	if err != nil {
-		fmt.Println(err)
-		raven.CaptureError(err, nil)
-	}
+	oyster_utils.LogIfError(err)
 
 	allGenesisHashes := make([]string, 0, len(allGenesisHashesStruct))
 
@@ -33,11 +27,7 @@ func PurgeCompletedSessions() {
 	err = models.DB.RawQuery("SELECT distinct genesis_hash FROM data_maps WHERE status != ? AND status != ?",
 		models.Complete,
 		models.Confirmed).All(&genesisHashesNotComplete)
-
-	if err != nil {
-		fmt.Println(err)
-		raven.CaptureError(err, nil)
-	}
+	oyster_utils.LogIfError(err)
 
 	notComplete := map[string]bool{}
 
@@ -56,8 +46,7 @@ func PurgeCompletedSessions() {
 
 				err = tx.RawQuery("DELETE from data_maps WHERE genesis_hash = ?", genesisHash).All(&[]models.DataMap{})
 				if err != nil {
-					fmt.Println(err)
-					raven.CaptureError(err, nil)
+					oyster_utils.LogIfError(err)
 					return err
 				}
 
@@ -65,8 +54,7 @@ func PurgeCompletedSessions() {
 
 				err = tx.RawQuery("SELECT * from upload_sessions WHERE genesis_hash = ?", genesisHash).All(&session)
 				if err != nil {
-					fmt.Println(err)
-					raven.CaptureError(err, nil)
+					oyster_utils.LogIfError(err)
 					return err
 				}
 
@@ -77,22 +65,19 @@ func PurgeCompletedSessions() {
 						FileSizeBytes: session[0].FileSizeBytes,
 					})
 					if err != nil {
-						fmt.Println(err)
-						raven.CaptureError(err, nil)
+						oyster_utils.LogIfError(err)
 						return err
 					}
 					err = models.NewCompletedUpload(session[0])
 					if err != nil {
-						fmt.Println(err)
-						raven.CaptureError(err, nil)
+						oyster_utils.LogIfError(err)
 						return err
 					}
 				}
 
 				err = tx.RawQuery("DELETE from upload_sessions WHERE genesis_hash = ?", genesisHash).All(&[]models.UploadSession{})
 				if err != nil {
-					fmt.Println(err)
-					raven.CaptureError(err, nil)
+					oyster_utils.LogIfError(err)
 					return err
 				}
 
@@ -125,9 +110,6 @@ func MoveToComplete(tx *pop.Connection, dataMaps []models.DataMap) {
 		}
 
 		_, err := tx.ValidateAndSave(&completedDataMap)
-		if err != nil {
-			fmt.Println(err)
-			raven.CaptureError(err, nil)
-		}
+		oyster_utils.LogIfError(err)
 	}
 }

--- a/jobs/update_timed_out_data_maps.go
+++ b/jobs/update_timed_out_data_maps.go
@@ -9,10 +9,10 @@ import (
 )
 
 func UpdateTimeOutDataMaps(thresholdTime time.Time) {
-
 	timedOutDataMaps := []models.DataMap{}
 
-	oyster_utils.LogIfError(models.DB.Where("status = ? AND updated_at <= ?", models.Unverified, thresholdTime).All(&timedOutDataMaps))
+	err := models.DB.Where("status = ? AND updated_at <= ?", models.Unverified, thresholdTime).All(&timedOutDataMaps)
+	oyster_utils.LogIfError(err)
 
 	if len(timedOutDataMaps) > 0 {
 

--- a/jobs/update_timed_out_data_maps.go
+++ b/jobs/update_timed_out_data_maps.go
@@ -1,27 +1,18 @@
 package jobs
 
 import (
-	"fmt"
 	"time"
 
-	"github.com/getsentry/raven-go"
 	"github.com/oysterprotocol/brokernode/models"
 	"github.com/oysterprotocol/brokernode/utils"
 	"gopkg.in/segmentio/analytics-go.v3"
 )
 
-func init() {
-}
-
 func UpdateTimeOutDataMaps(thresholdTime time.Time) {
 
 	timedOutDataMaps := []models.DataMap{}
 
-	err := models.DB.Where("status = ? AND updated_at <= ?", models.Unverified, thresholdTime).All(&timedOutDataMaps)
-	if err != nil {
-		fmt.Println(err)
-		raven.CaptureError(err, nil)
-	}
+	oyster_utils.LogIfError(models.DB.Where("status = ? AND updated_at <= ?", models.Unverified, thresholdTime).All(&timedOutDataMaps))
 
 	if len(timedOutDataMaps) > 0 {
 

--- a/jobs/verify_data_maps.go
+++ b/jobs/verify_data_maps.go
@@ -7,10 +7,10 @@ import (
 )
 
 func VerifyDataMaps(IotaWrapper services.IotaService) {
-
 	unverifiedDataMaps := []models.DataMap{}
 
-	oyster_utils.LogIfError(models.DB.Where("status = ?", models.Unverified).All(&unverifiedDataMaps))
+	err := models.DB.Where("status = ?", models.Unverified).All(&unverifiedDataMaps)
+	oyster_utils.LogIfError(err)
 
 	if len(unverifiedDataMaps) > 0 {
 		for i := 0; i < len(unverifiedDataMaps); i += BundleSize {
@@ -26,7 +26,6 @@ func VerifyDataMaps(IotaWrapper services.IotaService) {
 }
 
 func CheckChunks(IotaWrapper services.IotaService, unverifiedDataMaps []models.DataMap) {
-
 	filteredChunks, err := IotaWrapper.VerifyChunkMessagesMatchRecord(unverifiedDataMaps)
 	oyster_utils.LogIfError(err)
 

--- a/jobs/verify_data_maps.go
+++ b/jobs/verify_data_maps.go
@@ -1,24 +1,16 @@
 package jobs
 
 import (
-	"fmt"
-	raven "github.com/getsentry/raven-go"
 	"github.com/oysterprotocol/brokernode/models"
 	"github.com/oysterprotocol/brokernode/services"
+	"github.com/oysterprotocol/brokernode/utils"
 )
-
-func init() {
-}
 
 func VerifyDataMaps(IotaWrapper services.IotaService) {
 
 	unverifiedDataMaps := []models.DataMap{}
 
-	err := models.DB.Where("status = ?", models.Unverified).All(&unverifiedDataMaps)
-	if err != nil {
-		fmt.Println(err)
-		raven.CaptureError(err, nil)
-	}
+	oyster_utils.LogIfError(models.DB.Where("status = ?", models.Unverified).All(&unverifiedDataMaps))
 
 	if len(unverifiedDataMaps) > 0 {
 		for i := 0; i < len(unverifiedDataMaps); i += BundleSize {
@@ -36,11 +28,7 @@ func VerifyDataMaps(IotaWrapper services.IotaService) {
 func CheckChunks(IotaWrapper services.IotaService, unverifiedDataMaps []models.DataMap) {
 
 	filteredChunks, err := IotaWrapper.VerifyChunkMessagesMatchRecord(unverifiedDataMaps)
-
-	if err != nil {
-		fmt.Println(err)
-		raven.CaptureError(err, nil)
-	}
+	oyster_utils.LogIfError(err)
 
 	if len(filteredChunks.MatchesTangle) > 0 {
 

--- a/jobs/verify_data_maps_test.go
+++ b/jobs/verify_data_maps_test.go
@@ -11,9 +11,6 @@ var (
 )
 
 func (suite *JobsSuite) Test_VerifyDataMaps() {
-	// reset back to generic mocks
-	defer suite.SetupSuite()
-
 	// make suite available inside mock methods
 	Suite = *suite
 


### PR DESCRIPTION
* Use oyster_utils.LogIfError method through out this package.
* Clean Setting EthWrapper in individual file. Since method is static export, by call SetEthWrapper() will apply for all other files, while other can't access EthWrapper. Instead, use EthWrapper, ItoaWrapper defined in job_runner.go. And reset it each test. Each Unit test could change these two variable without affecting other tests case.