### PR TITLE
Don't send ETH when claiming PRLs

### DIFF
--- a/services/eth_gateway.go
+++ b/services/eth_gateway.go
@@ -647,12 +647,11 @@ func claimPRLs(receiverAddress common.Address, treasureAddress common.Address, t
 	if err != nil {
 		fmt.Print("Unable to instantiate OysterPearl")
 	}
-	prlBalance := checkPRLBalance(treasureAddress)
+
 	tx, err := oysterPearl.Claim(&bind.TransactOpts{
 		From:     auth.From,
 		Signer:   auth.Signer,
 		GasLimit: block.GasLimit(),
-		Value:    prlBalance,
 	}, receiverAddress, treasureAddress)
 
 	printTx(tx)


### PR DESCRIPTION
The claim amount is specified in the smart contract, this will send ETH, which we don't want.

Smart contract code for reference:
https://github.com/oysterprotocol/smartcontract/blob/master/contracts/OysterPearl.sol#L228