### PR TITLE
Server side limit

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -61,6 +61,14 @@ SENTRY_DSN=""
 GRIFT_ETH_PRIVATE_KEY="ba74b0e24739c1fa7e8470737635e6d894c1d6aefe98fa5b224e3a9f3139371a"
 
 #Oyster Pays
-#Set this to true if we are paying, otherwise can remove
-#or leave as an empty string
-OYSTER_PAYS="true"
+#Set this to true if we are paying, otherwise leave as an empty string
+OYSTER_PAYS=""
+
+# Num chunks limit
+# If there is a file size limit, define it here by constraining the number of
+# chunks allowed.  Use number of chunks instead of file size, because the data_maps
+# file uses num chunks to build the data map, so even if the client lies about num chunks
+# to get past this limit, their upload will fail.  1 kb = 1 chunk, so a 5 MB file will
+# have 5001 chunks (5000 file chunks + 1 metadata)
+# use "unlimited" for unlimited numChunks
+NUM_CHUNKS_LIMIT="5001"


### PR DESCRIPTION
-Add max number of chunks to .env.test file, to be added to prod broker's .env file.  
-Fail the upload if the file is over the maximum number of chunks.  

Even if the client "lies" about the number of chunks, the upload should still fail, because the broker will not complete the whole data map because it needs an accurate number of chunks to build the data map.  