### PR TITLE
QA webnode/brokernode fixes

### DIFF
--- a/models/data_maps_test.go
+++ b/models/data_maps_test.go
@@ -464,33 +464,3 @@ func (suite *ModelSuite) Test_AttachUnassignedChunksToGenHashMap() {
 
 	//fmt.Println(len(hashAndTypeMap))
 }
-
-/*
-Using this to compare with the webnode.  Will remove in future PR.
-func (ms *ModelSuite) Test_Webnode_Qa() {
-	genHash := "0dcb5642d72fb0b3ee9f01164f47ac7e8850d8bbe8a69e8de52afc32908f39d7"
-	numChunks := 7
-
-	vErr, err := models.BuildDataMaps(genHash, numChunks)
-	ms.Nil(err)
-	ms.Equal(0, len(vErr.Errors))
-
-	dMaps := []models.DataMap{}
-	ms.DB.Where("genesis_hash = ?", genHash).Order("chunk_idx asc").All(&dMaps)
-
-	ms.Equal(numChunks, len(dMaps))
-
-	fmt.Println("genesis hash:")
-	fmt.Println(genHash)
-	fmt.Println()
-
-	for _, dMap := range dMaps {
-		fmt.Println("hash")
-		fmt.Println(dMap.Hash)
-		fmt.Println("obfuscated hash")
-		fmt.Println(dMap.ObfuscatedHash)
-		fmt.Println("address")
-		fmt.Println(dMap.Address)
-		fmt.Println()
-	}
-}*/

--- a/models/stored_genesis_hashes.go
+++ b/models/stored_genesis_hashes.go
@@ -74,7 +74,6 @@ func (s *StoredGenesisHash) BeforeCreate(tx *pop.Connection) error {
 	return nil
 }
 
-//TODO: unit test this method
 func GetGenesisHashForWebnode(existingGenesisHashes []string) (StoredGenesisHash, error) {
 	//existingGenesisHashes are genesis hashes that the webnode already has
 	storedGenesisHashes := []StoredGenesisHash{}

--- a/models/stored_genesis_hashes.go
+++ b/models/stored_genesis_hashes.go
@@ -15,7 +15,10 @@ const (
 	StoredGenesisHashAssigned
 )
 
-const WebnodeCountLimit = 2
+const (
+	WebnodeCountLimit  = 2
+	NoGenHashesMessage = "no genesis hashes to sell, or none that this webnode needs"
+)
 
 type StoredGenesisHash struct {
 	ID            uuid.UUID `json:"id" db:"id"`
@@ -81,7 +84,7 @@ func GetGenesisHashForWebnode(existingGenesisHashes []string) (StoredGenesisHash
 		existingGenHashMap[genHash] = true
 	}
 
-	err := DB.Where("webnode_count < ? AND status = ?",
+	err := DB.Where("webnode_count < ? AND status = ? ORDER BY created_at asc",
 		WebnodeCountLimit, StoredGenesisHashUnassigned).All(&storedGenesisHashes)
 
 	if err != nil {
@@ -95,5 +98,5 @@ func GetGenesisHashForWebnode(existingGenesisHashes []string) (StoredGenesisHash
 		}
 	}
 
-	return StoredGenesisHash{}, errors.New("no genesis hashes to sell")
+	return StoredGenesisHash{}, errors.New(NoGenHashesMessage)
 }

--- a/models/stored_genesis_hashes_test.go
+++ b/models/stored_genesis_hashes_test.go
@@ -1,7 +1,171 @@
-package models
+package models_test
 
-import "testing"
+import (
+	"github.com/oysterprotocol/brokernode/models"
+	"time"
+)
 
-func Test_StoredGenesisHash(t *testing.T) {
-	t.Log("Nothing to test yet")
+func (ms *ModelSuite) Test_GetGenesisHashForWebnode_no_new_genesis_hashes() {
+
+	existingGenesisHashes := []string{
+		"abcdef11",
+		"abcdef12",
+		"abcdef13",
+	}
+
+	storedGenesisHash1 := models.StoredGenesisHash{
+		GenesisHash:   "abcdef11",
+		FileSizeBytes: 5000,
+		NumChunks:     5,
+		WebnodeCount:  0,
+		Status:        models.StoredGenesisHashUnassigned,
+	}
+
+	storedGenesisHash2 := models.StoredGenesisHash{
+		GenesisHash:   "abcdef11",
+		FileSizeBytes: 5000,
+		NumChunks:     5,
+		WebnodeCount:  0,
+		Status:        models.StoredGenesisHashUnassigned,
+	}
+
+	vErr, err := ms.DB.ValidateAndCreate(&storedGenesisHash1)
+	ms.Nil(err)
+	ms.Equal(0, len(vErr.Errors))
+
+	vErr, err = ms.DB.ValidateAndCreate(&storedGenesisHash2)
+	ms.Nil(err)
+	ms.Equal(0, len(vErr.Errors))
+
+	storedGenesisHash, err := models.GetGenesisHashForWebnode(existingGenesisHashes)
+
+	ms.Equal(models.StoredGenesisHash{}, storedGenesisHash)
+	ms.Equal(models.NoGenHashesMessage, err.Error())
+}
+
+func (ms *ModelSuite) Test_GetGenesisHashForWebnode_none_unassigned() {
+
+	existingGenesisHashes := []string{
+		"abcdef11",
+		"abcdef12",
+		"abcdef13",
+	}
+
+	storedGenesisHash1 := models.StoredGenesisHash{
+		GenesisHash:   "aaaaaa",
+		FileSizeBytes: 5000,
+		NumChunks:     5,
+		WebnodeCount:  0,
+		Status:        models.StoredGenesisHashAssigned, // assigned already
+	}
+
+	vErr, err := ms.DB.ValidateAndCreate(&storedGenesisHash1)
+	ms.Nil(err)
+	ms.Equal(0, len(vErr.Errors))
+
+	storedGenesisHash, err := models.GetGenesisHashForWebnode(existingGenesisHashes)
+
+	ms.Equal(models.StoredGenesisHash{}, storedGenesisHash)
+	ms.Equal(models.NoGenHashesMessage, err.Error())
+}
+
+func (ms *ModelSuite) Test_GetGenesisHashForWebnode_none_below_webnode_count_limit() {
+
+	existingGenesisHashes := []string{
+		"abcdef11",
+		"abcdef12",
+		"abcdef13",
+	}
+
+	storedGenesisHash1 := models.StoredGenesisHash{
+		GenesisHash:   "aaaaaa",
+		FileSizeBytes: 5000,
+		NumChunks:     5,
+		WebnodeCount:  models.WebnodeCountLimit + 1, // over the limit
+		Status:        models.StoredGenesisHashUnassigned,
+	}
+
+	vErr, err := ms.DB.ValidateAndCreate(&storedGenesisHash1)
+	ms.Nil(err)
+	ms.Equal(0, len(vErr.Errors))
+
+	storedGenesisHash, err := models.GetGenesisHashForWebnode(existingGenesisHashes)
+
+	ms.Equal(models.StoredGenesisHash{}, storedGenesisHash)
+	ms.Equal(models.NoGenHashesMessage, err.Error())
+}
+
+func (ms *ModelSuite) Test_GetGenesisHashForWebnode_success() {
+
+	existingGenesisHashes := []string{
+		"abcdef11",
+		"abcdef12",
+		"abcdef13",
+	}
+
+	genesisHash := "aaaaaa"
+
+	storedGenesisHash1 := models.StoredGenesisHash{
+		GenesisHash:   genesisHash,
+		FileSizeBytes: 5000,
+		NumChunks:     5,
+		WebnodeCount:  0,
+		Status:        models.StoredGenesisHashUnassigned,
+	}
+
+	vErr, err := ms.DB.ValidateAndCreate(&storedGenesisHash1)
+	ms.Nil(err)
+	ms.Equal(0, len(vErr.Errors))
+
+	storedGenesisHash, err := models.GetGenesisHashForWebnode(existingGenesisHashes)
+
+	ms.Equal(storedGenesisHash1.GenesisHash, storedGenesisHash.GenesisHash)
+	ms.Nil(err)
+}
+
+func (ms *ModelSuite) Test_GetGenesisHashForWebnode_success_return_oldest() {
+
+	existingGenesisHashes := []string{
+		"abcdef11",
+		"abcdef12",
+		"abcdef13",
+	}
+
+	newerGenesisHash := "aaaaaa"
+	olderGenesisHash := "bbbbbb"
+
+	storedGenesisHash1 := models.StoredGenesisHash{
+		GenesisHash:   newerGenesisHash,
+		FileSizeBytes: 5000,
+		NumChunks:     5,
+		WebnodeCount:  0,
+		Status:        models.StoredGenesisHashUnassigned,
+	}
+
+	storedGenesisHash2 := models.StoredGenesisHash{
+		GenesisHash:   olderGenesisHash,
+		FileSizeBytes: 5000,
+		NumChunks:     5,
+		WebnodeCount:  0,
+		Status:        models.StoredGenesisHashUnassigned,
+	}
+
+	vErr, err := ms.DB.ValidateAndCreate(&storedGenesisHash1)
+	ms.Nil(err)
+	ms.Equal(0, len(vErr.Errors))
+
+	vErr, err = ms.DB.ValidateAndCreate(&storedGenesisHash2)
+	ms.Nil(err)
+	ms.Equal(0, len(vErr.Errors))
+
+	// forcibly updated the "created_at" time for the second stored_genesis_hash so it will be
+	// older
+	err = ms.DB.RawQuery("UPDATE stored_genesis_hashes SET created_at = ? WHERE genesis_hash = ?",
+		time.Now().Add(-20*time.Second), storedGenesisHash2.GenesisHash).All(&[]models.StoredGenesisHash{})
+	ms.Nil(err)
+
+	storedGenesisHash, err := models.GetGenesisHashForWebnode(existingGenesisHashes)
+
+	ms.Equal(olderGenesisHash, storedGenesisHash.GenesisHash)
+	ms.Nil(err)
 }


### PR DESCRIPTION
While Edmund was QAing webnode/brokernode interaction, we found some errors.  This PR fixes those errors.  

-gobuffalo seems to have problems with NOT IN (?) queries so I have removed that
-better error messages
-no longer change the genesis hash status to assigned, if it has been assigned to fewer webnodes that WebnodeCountLimit
-for verifying the PoW, we were looking for the genesis hash match in the wrong table.  
-move the query to get the stored genesis hashes to the stored genesis hashes models file. 