### PR TITLE
Move version to different migration file

### DIFF
--- a/migrations/20180316183149_create_upload_sessions.up.fizz
+++ b/migrations/20180316183149_create_upload_sessions.up.fizz
@@ -14,7 +14,6 @@ create_table("upload_sessions", func(t) {
 	t.Column("treasure_status", "integer", {})
 
 	t.Column("treasure_idx_map", "JSON", {"null": true})
-	t.Column("version", "INT UNSIGNED", {"null": true, "default": 1})
 })
 
 add_index("upload_sessions", "genesis_hash", {"unique": true})

--- a/migrations/20180422152102_create_completed_uploads.up.fizz
+++ b/migrations/20180422152102_create_completed_uploads.up.fizz
@@ -7,7 +7,6 @@ create_table("completed_uploads", func(t) {
 
 	t.Column("prl_status", "integer", {})
 	t.Column("gas_status", "integer", {})
-	t.Column("version", "INT UNSIGNED", {"null": true, "default": 1})
 })
 
 add_index("completed_uploads", "genesis_hash", {"unique": true})

--- a/migrations/20180611231123_add_version_to_upload_sessions.up.fizz
+++ b/migrations/20180611231123_add_version_to_upload_sessions.up.fizz
@@ -1,0 +1,1 @@
+add_column("upload_sessions", "version", "INT UNSIGNED", {"null": true, "default": 1})

--- a/migrations/20180611231345_add_version_to_completed_uploads.up.fizz
+++ b/migrations/20180611231345_add_version_to_completed_uploads.up.fizz
@@ -1,0 +1,1 @@
+add_column("completed_uploads", "version", "INT UNSIGNED", {"null": true, "default": 1})


### PR DESCRIPTION
Put the version addition in its own migration file.  Should have done this to begin with.  