### PR TITLE
Just disable Job run in test

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -45,6 +45,8 @@ MODE="PROD_MODE"
 
 # Disable Job runner, If set to false/"false", it will disable jobs module to run
 # on the background. If not set, or set to any other value, it would enable jobs module.
+# Note: it does not make sense to run background job during unit test run. Thus, this flag
+# will be ignored.
 JOB_RUNNER=false
 
 # Experimental

--- a/.env.test
+++ b/.env.test
@@ -43,12 +43,6 @@ MODE="PROD_MODE"
 # MODE="TEST_MODE_DUMMY_TREASURE"
 # MODE="TEST_MODE_NO_TREASURE"
 
-# Disable Job runner, If set to false/"false", it will disable jobs module to run
-# on the background. If not set, or set to any other value, it would enable jobs module.
-# Note: it does not make sense to run background job during unit test run. Thus, this flag
-# will be ignored.
-JOB_RUNNER=false
-
 # Experimental
 # May not need these
 

--- a/jobs/job_runner.go
+++ b/jobs/job_runner.go
@@ -4,8 +4,8 @@ import (
 	"os"
 	"reflect"
 	"runtime"
-	"time"
 	"strconv"
+	"time"
 
 	"github.com/gobuffalo/buffalo/worker"
 	"github.com/oysterprotocol/brokernode/services"
@@ -20,13 +20,15 @@ const (
 var OysterWorker = worker.NewSimple()
 
 var (
-	IotaWrapper = services.IotaWrapper
-	EthWrapper  = services.EthWrapper
-	PrometheusWrapper  = services.PrometheusWrapper
+	IotaWrapper       = services.IotaWrapper
+	EthWrapper        = services.EthWrapper
+	PrometheusWrapper = services.PrometheusWrapper
 )
 
 func init() {
-	if enabled, err := strconv.ParseBool(os.Getenv("JOB_RUNNER")); err == nil && !enabled {
+	enabled, err := strconv.ParseBool(os.Getenv("JOB_RUNNER"))
+	isEnvDisabled = err == nil && !enabled
+	if isEnvDisabled || oyster_utils.IsUnitTest() {
 		return
 	}
 
@@ -119,7 +121,7 @@ func verifyDataMapsHandler(args worker.Args) error {
 }
 
 func updateTimedOutDataMapsHandler(args worker.Args) error {
-	UpdateTimeOutDataMaps(time.Now().Add(-2 * time.Minute), PrometheusWrapper)
+	UpdateTimeOutDataMaps(time.Now().Add(-2*time.Minute), PrometheusWrapper)
 
 	oysterWorkerPerformIn(updateTimedOutDataMapsHandler, args)
 	return nil

--- a/jobs/job_runner.go
+++ b/jobs/job_runner.go
@@ -26,9 +26,7 @@ var (
 )
 
 func init() {
-	enabled, err := strconv.ParseBool(os.Getenv("JOB_RUNNER"))
-	isEnvDisabled := err == nil && !enabled
-	if isEnvDisabled || oyster_utils.IsInUnitTest() {
+	if oyster_utils.IsInUnitTest() {
 		return
 	}
 

--- a/jobs/job_runner.go
+++ b/jobs/job_runner.go
@@ -28,7 +28,7 @@ var (
 func init() {
 	enabled, err := strconv.ParseBool(os.Getenv("JOB_RUNNER"))
 	isEnvDisabled := err == nil && !enabled
-	if isEnvDisabled || oyster_utils.IsUnitTest() {
+	if isEnvDisabled || oyster_utils.IsInUnitTest() {
 		return
 	}
 

--- a/jobs/job_runner.go
+++ b/jobs/job_runner.go
@@ -4,7 +4,6 @@ import (
 	"os"
 	"reflect"
 	"runtime"
-	"strconv"
 	"time"
 
 	"github.com/gobuffalo/buffalo/worker"

--- a/jobs/job_runner.go
+++ b/jobs/job_runner.go
@@ -27,7 +27,7 @@ var (
 
 func init() {
 	enabled, err := strconv.ParseBool(os.Getenv("JOB_RUNNER"))
-	isEnvDisabled = err == nil && !enabled
+	isEnvDisabled := err == nil && !enabled
 	if isEnvDisabled || oyster_utils.IsUnitTest() {
 		return
 	}

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -44,15 +44,7 @@ var isRavenEnabled bool = true
 var logErrorTags map[string]string
 
 func init() {
-	// Check whether current is in unit test mode.
-	// If provided -v, then it would be -test.v=true. By default, it would output to a log dir
-	// with the following format: -test.testlogfile=/tmp/go-build797632719/b292/testlog.txt
-	for _, v := range os.Args {
-		if strings.HasPrefix(v, "-test.") {
-			isRavenEnabled = false
-			break
-		}
-	}
+	isRavenEnabled = !IsInUnitTest()
 
 	isOysterPay := "enabled"
 	if os.Getenv("OYSTER_PAYS") == "" {
@@ -65,6 +57,19 @@ func init() {
 		"osyterPay":   isOysterPay,
 		"displayName": os.Getenv("DISPLAY_NAME"),
 	}
+}
+
+/*IsInUnitTest returns true if it is running in test mode.*/
+func IsInUnitTest() bool {
+	// Check whether current is in unit test mode.
+	// If provided -v, then it would be -test.v=true. By default, it would output to a log dir
+	// with the following format: -test.testlogfile=/tmp/go-build797632719/b292/testlog.txt
+	for _, v := range os.Args {
+		if strings.HasPrefix(v, "-test.") {
+			return true
+		}
+	}
+	return false
 }
 
 /*IsRavenEnabled returns whether Raven logging is enabled or disabled.*/

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -8,6 +8,12 @@ import (
 	"github.com/oysterprotocol/brokernode/utils"
 )
 
+func Test_IsUnitTestEnabled(t *testing.T) {
+	v := oyster_utils.IsInUnitTest()
+
+	oyster_utils.AssertTrue(v, t, "")
+}
+
 func Test_IsRavenEnabled(t *testing.T) {
 	v := oyster_utils.IsRavenEnabled()
 


### PR DESCRIPTION
It does not make sense to have job run in the background during unit test. For unit test for job run, they should manually enable the each test.

This will reduce some sentry.io error