### PR TITLE
Add msgStatus column in DataMaps

### DIFF
--- a/migrations/20180623145457_add_msg_status.down.fizz
+++ b/migrations/20180623145457_add_msg_status.down.fizz
@@ -1,0 +1,1 @@
+drop_column("data_maps", "msg_status")

--- a/migrations/20180623145457_add_msg_status.up.fizz
+++ b/migrations/20180623145457_add_msg_status.up.fizz
@@ -1,0 +1,1 @@
+add_column("data_maps", "msg_status", "integer", {"null": true, "default": 0})

--- a/models/data_maps.go
+++ b/models/data_maps.go
@@ -50,6 +50,7 @@ type DataMap struct {
 	NodeType       string    `json:"nodeType" db:"node_type"`
 	Message        string    `json:"message" db:"message"`
 	MsgID          string    `json:"msgId" db:"msg_id"`
+	MsgStatus      int       `json:"msgStatus" db:"msg_status"`
 	TrunkTx        string    `json:"trunkTx" db:"trunk_tx"`
 	BranchTx       string    `json:"branchTx" db:"branch_tx"`
 	GenesisHash    string    `json:"genesisHash" db:"genesis_hash"`


### PR DESCRIPTION
msgStatus will be represent the status of message. Does brokernode hve it or not. It will enable brokernode to do efficient query such as give me all the dataMaps object where its message is uploaded.

Follow up PR will use this field.