### PR TITLE
claim_unused_prls QA completed live on the eth network

### DIFF
--- a/jobs/bury_treasure_addresses.go
+++ b/jobs/bury_treasure_addresses.go
@@ -387,7 +387,11 @@ func sendGas(treasureToBury models.Treasure) {
 		return
 	}
 
-	_, txHash, nonce, err := EthWrapper.SendETH(services.StringToAddress(treasureToBury.ETHAddr), gasToSend)
+	_, txHash, nonce, err := EthWrapper.SendETH(
+		services.MainWalletAddress,
+		services.MainWalletPrivateKey,
+		services.StringToAddress(treasureToBury.ETHAddr),
+		gasToSend)
 	if err != nil {
 		errorString := "\nFailure sending " + fmt.Sprint(gasToSend.Int64()) + " Gas to " + treasureToBury.ETHAddr
 		err := errors.New(errorString)

--- a/jobs/bury_treasure_addresses_test.go
+++ b/jobs/bury_treasure_addresses_test.go
@@ -1,6 +1,7 @@
 package jobs_test
 
 import (
+	"crypto/ecdsa"
 	"errors"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -246,10 +247,11 @@ func (suite *JobsSuite) Test_SendGasToTreasureAddresses() {
 			}
 			return big.NewInt(600000000000000000)
 		},
-		SendETH: func(address common.Address, gas *big.Int) (types.Transactions, string, int64, error) {
+		SendETH: func(fromAddress common.Address, fromPrivKey *ecdsa.PrivateKey, toAddress common.Address,
+			gas *big.Int) (types.Transactions, string, int64, error) {
 			hasCalledSendGas = true
 			// make one of the transfers unsuccessful
-			if address == services.StringToAddress(failSendEthAddress) {
+			if toAddress == services.StringToAddress(failSendEthAddress) {
 				return types.Transactions{}, "", -1, errors.New("FAIL")
 			}
 			return types.Transactions{}, "111111", 1, nil

--- a/jobs/job_runner.go
+++ b/jobs/job_runner.go
@@ -155,7 +155,7 @@ func buryTreasureAddressesHandler(args worker.Args) error {
 }
 
 func claimUnusedPRLsHandler(args worker.Args) error {
-	thresholdTime := time.Now().Add(-3 * time.Hour) // consider a transaction timed out if it takes more than 3 hours
+	thresholdTime := time.Now().Add(-12 * time.Hour) // consider a transaction timed out after 12 hours
 	ClaimUnusedPRLs(thresholdTime, PrometheusWrapper)
 
 	oysterWorkerPerformIn(claimUnusedPRLsHandler, args)

--- a/migrations/20180611231123_add_version_to_upload_sessions.down.fizz
+++ b/migrations/20180611231123_add_version_to_upload_sessions.down.fizz
@@ -1,0 +1,1 @@
+drop_column("upload_sessions", "version")

--- a/migrations/20180611231345_add_version_to_completed_uploads.down.fizz
+++ b/migrations/20180611231345_add_version_to_completed_uploads.down.fizz
@@ -1,0 +1,1 @@
+drop_column("completed_uploads", "version")

--- a/migrations/20180621123456_add_transaction_data_to_treasures.down.fizz
+++ b/migrations/20180621123456_add_transaction_data_to_treasures.down.fizz
@@ -1,0 +1,7 @@
+drop_column("treasures", "genesis_hash")
+drop_column("treasures", "prl_tx_hash")
+drop_column("treasures", "prl_tx_nonce")
+drop_column("treasures", "gas_tx_hash")
+drop_column("treasures", "gas_tx_nonce")
+drop_column("treasures", "bury_tx_hash")
+drop_column("treasures", "bury_tx_nonce")

--- a/migrations/20180621213452_add_transaction_data_to_completed_uploads.down.fizz
+++ b/migrations/20180621213452_add_transaction_data_to_completed_uploads.down.fizz
@@ -1,0 +1,4 @@
+drop_column("completed_uploads", "prl_tx_hash")
+drop_column("completed_uploads", "prl_tx_nonce")
+drop_column("completed_uploads", "gas_tx_hash")
+drop_column("completed_uploads", "gas_tx_nonce")

--- a/migrations/20180625135525_add_treasure_status_to_stored_genesis_hashes.down.fizz
+++ b/migrations/20180625135525_add_treasure_status_to_stored_genesis_hashes.down.fizz
@@ -1,0 +1,1 @@
+drop_column("stored_genesis_hashes", "treasure_status")

--- a/services/eth_gateway_test.go
+++ b/services/eth_gateway_test.go
@@ -234,7 +234,11 @@ func Test_sendEth(t *testing.T) {
 	transferValue := big.NewInt(1)
 	transferValueInWei := new(big.Int).Mul(transferValue, oneWei)
 	// Send ether to test account
-	txs, _, _, err := services.EthWrapper.SendETH(ethAddress02, transferValueInWei)
+
+	prlWallet := getWallet(prl1File)
+
+	txs, _, _, err := services.EthWrapper.SendETH(prlWallet.Address,
+		prlWallet.PrivateKey, ethAddress02, transferValueInWei)
 	if err != nil {
 		t.Logf("failed to send ether to %v ether to %v\n", transferValue, ethAddress02.Hex())
 		t.Fatalf("transaction error: %v\n", err)


### PR DESCRIPTION
-adds more grifts which I used to QA the claim_unused_prls task
-QA'd to verify that brokernode successfully goes through this sequence:
      1.  Send small amount of gas to the transaction address
      2.  Use that gas to retrieve the PRL at the transaction address to the broker's wallet 
      3.  If there's some ETH still left in the transaction address, retrieve it to the broker's wallet
-adds more methods needed to accomplish the sequence
-adds unit tests of the new methods
-modifies SendETH method to be used with any "from" address that we have the key for
-adds missing down migration files

