### PR TITLE
Add check at end of generateEthAddr to always result in keys with 64 characters

### DIFF
--- a/services/eth_gateway.go
+++ b/services/eth_gateway.go
@@ -279,7 +279,7 @@ func generateEthAddr() (addr common.Address, privateKey string, err error) {
 	}
 	addr = crypto.PubkeyToAddress(ethAccount.PublicKey)
 	privateKey = hex.EncodeToString(ethAccount.D.Bytes())
-	if privateKey[0] == '0' {
+	if privateKey[0] == '0' || len(privateKey) != 64 {
 		return generateEthAddr()
 	}
 	return addr, privateKey, err


### PR DESCRIPTION
Sometimes the `generateEthAddr` method produces a 62 character long key instead of 64 characters long.  This breaks things.  It does not appear to be anything we are doing but an issue with the ethereum crypto library.  It very rarely happens so the fix for now is to just check at the end of the method if the private key is not 64 characters long, and if it's not, call the method recursively.  