### PR TITLE
Clean up Unit test assertion.

### DIFF
--- a/jobs/bury_treasure_addresses_test.go
+++ b/jobs/bury_treasure_addresses_test.go
@@ -29,14 +29,14 @@ func (suite *JobsSuite) Test_CheckPRLTransactions() {
 	suite.Nil(err)
 	suite.Equal(1, len(pendingPRL))
 
-	suite.Equal(false, hasCalledCheckPRLBalance)
+	suite.False(hasCalledCheckPRLBalance)
 
 	jobs.CheckPRLTransactions()
 
 	pendingPRL, err = models.GetTreasuresToBuryByPRLStatus([]models.PRLStatus{models.PRLPending})
 	suite.Nil(err)
 	suite.Equal(0, len(pendingPRL))
-	suite.Equal(true, hasCalledCheckPRLBalance)
+	suite.True(hasCalledCheckPRLBalance)
 }
 
 func (suite *JobsSuite) Test_CheckGasTransactions() {
@@ -55,14 +55,14 @@ func (suite *JobsSuite) Test_CheckGasTransactions() {
 	suite.Nil(err)
 	suite.Equal(1, len(pendingGas))
 
-	suite.Equal(false, hasCalledCheckETHBalance)
+	suite.False(hasCalledCheckETHBalance)
 
 	jobs.CheckGasTransactions()
 
 	pendingGas, err = models.GetTreasuresToBuryByPRLStatus([]models.PRLStatus{models.GasPending})
 	suite.Nil(err)
 	suite.Equal(0, len(pendingGas))
-	suite.Equal(true, hasCalledCheckETHBalance)
+	suite.True(hasCalledCheckETHBalance)
 }
 
 func (suite *JobsSuite) Test_SetTimedOutTransactionsToError() {
@@ -221,8 +221,8 @@ func (suite *JobsSuite) Test_SendPRLsToWaitingTreasureAddresses() {
 	suite.Nil(err)
 	suite.Equal(1, len(errored))
 
-	suite.Equal(true, hasCalledCheckPRLBalance)
-	suite.Equal(true, hasCalledSendPRL)
+	suite.True(hasCalledCheckPRLBalance)
+	suite.True(hasCalledSendPRL)
 }
 
 func (suite *JobsSuite) Test_SendGasToTreasureAddresses() {
@@ -289,9 +289,9 @@ func (suite *JobsSuite) Test_SendGasToTreasureAddresses() {
 	suite.Nil(err)
 	suite.Equal(1, len(errored))
 
-	suite.Equal(true, hasCalledCalculateGasNeeded)
-	suite.Equal(true, hasCalledCheckETHBalance)
-	suite.Equal(true, hasCalledSendGas)
+	suite.True(hasCalledCalculateGasNeeded)
+	suite.True(hasCalledCheckETHBalance)
+	suite.True(hasCalledSendGas)
 }
 
 func (suite *JobsSuite) Test_InvokeBury() {
@@ -363,10 +363,10 @@ func (suite *JobsSuite) Test_InvokeBury() {
 	suite.Nil(err)
 	suite.Equal(1, len(errored))
 
-	suite.Equal(true, hasCalledCheckPRLBalance)
-	suite.Equal(true, hasCalledCheckETHBalance)
-	suite.Equal(true, hasCalledBuryPRL)
-	suite.Equal(true, hasCalledCheckBuryStatus)
+	suite.True(hasCalledCheckPRLBalance)
+	suite.True(hasCalledCheckETHBalance)
+	suite.True(hasCalledBuryPRL)
+	suite.True(hasCalledCheckBuryStatus)
 }
 
 func (suite *JobsSuite) Test_PurgeFinishedTreasure() {

--- a/jobs/check_alpha_payments_test.go
+++ b/jobs/check_alpha_payments_test.go
@@ -374,7 +374,7 @@ func generateBrokerBrokerTransactions(suite *JobsSuite,
 
 		vErr, err := suite.DB.ValidateAndCreate(&brokerTx)
 		suite.Nil(err)
-		suite.Equal(0, len(vErr.Errors))
+		suite.False(vErr.HasAny())
 	}
 }
 

--- a/jobs/claim_unused_prls_test.go
+++ b/jobs/claim_unused_prls_test.go
@@ -61,97 +61,97 @@ func testResendTimedOutGasTransfers(suite *JobsSuite) {
 	testSetup(suite)
 
 	suite.Equal(0, SentToSendETH)
-	suite.Equal(false, hasCalledSendETH)
+	suite.False(hasCalledSendETH)
 
 	jobs.ResendTimedOutGasTransfers(time.Now().Add(30 * time.Minute))
 	// should be one timed out
 	suite.Equal(1, SentToSendETH)
-	suite.Equal(true, hasCalledSendETH)
+	suite.True(hasCalledSendETH)
 
 	resetTestVariables()
 
 	jobs.ResendTimedOutGasTransfers(time.Now().Add(-20 * time.Minute))
 	// should be none, nothing timed out yet
 	suite.Equal(0, SentToSendETH)
-	suite.Equal(false, hasCalledSendETH)
+	suite.False(hasCalledSendETH)
 }
 
 func testResendTimedOutPRLTransfers(suite *JobsSuite) {
 	testSetup(suite)
 
 	suite.Equal(0, SentToSendPRLFromOyster)
-	suite.Equal(false, hasCalledSendPRLFromOyster)
+	suite.False(hasCalledSendPRLFromOyster)
 
 	jobs.ResendTimedOutPRLTransfers(time.Now().Add(30 * time.Minute))
 	// should be one timed out
 	suite.Equal(1, SentToSendPRLFromOyster)
-	suite.Equal(true, hasCalledSendPRLFromOyster)
+	suite.True(hasCalledSendPRLFromOyster)
 
 	resetTestVariables()
 
 	jobs.ResendTimedOutPRLTransfers(time.Now().Add(-20 * time.Minute))
 	// should be none, nothing timed out yet
 	suite.Equal(0, SentToSendPRLFromOyster)
-	suite.Equal(false, hasCalledSendPRLFromOyster)
+	suite.False(hasCalledSendPRLFromOyster)
 }
 
 func testResendErroredGasTransfers(suite *JobsSuite) {
 	testSetup(suite)
 
 	suite.Equal(0, SentToSendETH)
-	suite.Equal(false, hasCalledSendETH)
+	suite.False(hasCalledSendETH)
 
 	jobs.ResendErroredGasTransfers()
 
 	// should be one error'd gas transfer that gets resent
 	suite.Equal(1, SentToSendETH)
-	suite.Equal(true, hasCalledSendETH)
+	suite.True(hasCalledSendETH)
 }
 
 func testResendErroredPRLTransfers(suite *JobsSuite) {
 	testSetup(suite)
 
 	suite.Equal(0, SentToSendPRLFromOyster)
-	suite.Equal(false, hasCalledSendPRLFromOyster)
+	suite.False(hasCalledSendPRLFromOyster)
 
 	jobs.ResendErroredPRLTransfers()
 
 	// should be one error'd prl transfer that gets resent
 	suite.Equal(1, SentToSendPRLFromOyster)
-	suite.Equal(true, hasCalledSendPRLFromOyster)
+	suite.True(hasCalledSendPRLFromOyster)
 }
 
 func testSendGasForNewClaims(suite *JobsSuite) {
 	testSetup(suite)
 
 	suite.Equal(0, SentToSendETH)
-	suite.Equal(false, hasCalledSendETH)
+	suite.False(hasCalledSendETH)
 
 	jobs.SendGasForNewClaims()
 
 	// should be one new gas transfer that gets sent
 	suite.Equal(1, SentToSendETH)
-	suite.Equal(true, hasCalledSendETH)
+	suite.True(hasCalledSendETH)
 }
 
 func testStartNewClaims(suite *JobsSuite) {
 	testSetup(suite)
 
 	suite.Equal(0, SentToSendPRLFromOyster)
-	suite.Equal(false, hasCalledSendPRLFromOyster)
+	suite.False(hasCalledSendPRLFromOyster)
 
 	jobs.StartNewClaims()
 
 	// should be one new prl claim that gets sent
 	suite.Equal(1, SentToSendPRLFromOyster)
-	suite.Equal(true, hasCalledSendPRLFromOyster)
+	suite.True(hasCalledSendPRLFromOyster)
 }
 
 func testRetrieveLeftoverETH(suite *JobsSuite) {
 	testSetup(suite)
 
 	suite.Equal(0, SentToSendETH)
-	suite.Equal(false, hasCalledSendETH)
+	suite.False(hasCalledSendETH)
 
 	completedUploads := []models.CompletedUpload{}
 	err := suite.DB.All(&completedUploads)
@@ -162,15 +162,15 @@ func testRetrieveLeftoverETH(suite *JobsSuite) {
 
 	// should be 1 call to retrieve leftover gas
 	suite.Equal(1, SentToSendETH)
-	suite.Equal(true, hasCalledSendETH)
-	suite.Equal(true, hasCalledCheckETHBalance)
+	suite.True(hasCalledSendETH)
+	suite.True(hasCalledCheckETHBalance)
 }
 
 func testInitiateGasTransfer(suite *JobsSuite) {
 	testSetup(suite)
 
 	suite.Equal(0, SentToSendETH)
-	suite.Equal(false, hasCalledSendETH)
+	suite.False(hasCalledSendETH)
 
 	completedUploads := []models.CompletedUpload{}
 	err := suite.DB.RawQuery("SELECT * from completed_uploads WHERE gas_status != ?",
@@ -181,14 +181,14 @@ func testInitiateGasTransfer(suite *JobsSuite) {
 	jobs.InitiateGasTransfer(completedUploads)
 
 	suite.Equal(len(completedUploads), SentToSendETH)
-	suite.Equal(true, hasCalledSendETH)
+	suite.True(hasCalledSendETH)
 }
 
 func testInitiatePRLClaim(suite *JobsSuite) {
 	testSetup(suite)
 
 	suite.Equal(0, SentToSendPRLFromOyster)
-	suite.Equal(false, hasCalledSendPRLFromOyster)
+	suite.False(hasCalledSendPRLFromOyster)
 
 	completedUploads := []models.CompletedUpload{}
 	err := suite.DB.All(&completedUploads)
@@ -198,8 +198,8 @@ func testInitiatePRLClaim(suite *JobsSuite) {
 	jobs.InitiatePRLClaim(completedUploads)
 
 	suite.Equal(len(completedUploads), SentToSendPRLFromOyster)
-	suite.Equal(true, hasCalledSendPRLFromOyster)
-	suite.Equal(true, hasCalledCheckPRLBalance)
+	suite.True(hasCalledSendPRLFromOyster)
+	suite.True(hasCalledCheckPRLBalance)
 }
 
 func testPurgeCompletedClaims(suite *JobsSuite) {
@@ -240,7 +240,7 @@ func testCheckProcessingGasTransactions_transaction_succeeded(suite *JobsSuite) 
 		"completed_uploads WHERE gas_status = ?", models.GasTransferProcessing).All(&gasTransfersProcessing)
 	suite.Nil(err)
 	suite.Equal(0, len(gasTransfersProcessing))
-	suite.Equal(true, hasCalledCheckETHBalance)
+	suite.True(hasCalledCheckETHBalance)
 }
 
 func testCheckProcessingGasTransactions_still_pending(suite *JobsSuite) {
@@ -269,7 +269,7 @@ func testCheckProcessingGasTransactions_still_pending(suite *JobsSuite) {
 		"completed_uploads WHERE gas_status = ?", models.GasTransferProcessing).All(&gasTransfersProcessing)
 	suite.Nil(err)
 	suite.Equal(1, len(gasTransfersProcessing))
-	suite.Equal(true, hasCalledCheckETHBalance)
+	suite.True(hasCalledCheckETHBalance)
 }
 
 func testCheckProcessingPRLTransactions_transaction_succeeded(suite *JobsSuite) {
@@ -298,7 +298,7 @@ func testCheckProcessingPRLTransactions_transaction_succeeded(suite *JobsSuite) 
 		"completed_uploads WHERE prl_status = ?", models.PRLClaimProcessing).All(&transfersProcessing)
 	suite.Nil(err)
 	suite.Equal(0, len(transfersProcessing))
-	suite.Equal(true, hasCalledCheckPRLBalance)
+	suite.True(hasCalledCheckPRLBalance)
 }
 
 func testCheckProcessingPRLTransactions_still_pending(suite *JobsSuite) {
@@ -321,7 +321,7 @@ func testCheckProcessingPRLTransactions_still_pending(suite *JobsSuite) {
 		"completed_uploads WHERE prl_status = ?", models.PRLClaimProcessing).All(&transfersProcessing)
 	suite.Nil(err)
 	suite.Equal(1, len(transfersProcessing))
-	suite.Equal(true, hasCalledCheckPRLBalance)
+	suite.True(hasCalledCheckPRLBalance)
 }
 
 func testCheckProcessingGasReclaims_reclaim_complete(suite *JobsSuite) {
@@ -351,7 +351,7 @@ func testCheckProcessingGasReclaims_reclaim_complete(suite *JobsSuite) {
 		"completed_uploads WHERE gas_status = ?", models.GasTransferLeftoversReclaimProcessing).All(&transfersProcessing)
 	suite.Nil(err)
 	suite.Equal(0, len(transfersProcessing))
-	suite.Equal(true, hasCalledCheckETHBalance)
+	suite.True(hasCalledCheckETHBalance)
 }
 
 func testCheckProcessingGasReclaims_not_enough_to_reclaim(suite *JobsSuite) {
@@ -384,7 +384,7 @@ func testCheckProcessingGasReclaims_not_enough_to_reclaim(suite *JobsSuite) {
 		"completed_uploads WHERE gas_status = ?", models.GasTransferLeftoversReclaimProcessing).All(&transfersProcessing)
 	suite.Nil(err)
 	suite.Equal(0, len(transfersProcessing))
-	suite.Equal(true, hasCalledCheckETHBalance)
+	suite.True(hasCalledCheckETHBalance)
 }
 
 func testCheckProcessingGasReclaims_still_pending(suite *JobsSuite) {
@@ -421,7 +421,7 @@ func testCheckProcessingGasReclaims_still_pending(suite *JobsSuite) {
 		"completed_uploads WHERE gas_status = ?", models.GasTransferLeftoversReclaimProcessing).All(&transfersProcessing)
 	suite.Nil(err)
 	suite.Equal(1, len(transfersProcessing))
-	suite.Equal(true, hasCalledCheckETHBalance)
+	suite.True(hasCalledCheckETHBalance)
 }
 
 func testResendTimedOutGasReclaims(suite *JobsSuite) {

--- a/jobs/process_paid_sessions_test.go
+++ b/jobs/process_paid_sessions_test.go
@@ -141,6 +141,6 @@ func (suite *JobsSuite) Test_ProcessPaidSessions() {
 
 	for _, entry := range treasureIndex {
 		_, ok := treasureIndexes[entry.Idx]
-		suite.Equal(true, ok)
+		suite.True(ok)
 	}
 }

--- a/jobs/process_unassigned_chunks_test.go
+++ b/jobs/process_unassigned_chunks_test.go
@@ -95,8 +95,8 @@ func (suite *JobsSuite) Test_ProcessUnassignedChunks() {
 	// call method under test
 	jobs.ProcessUnassignedChunks(IotaMock, jobs.PrometheusWrapper)
 
-	suite.Equal(true, sendChunksToChannelMockCalled_process_unassigned_chunks)
-	suite.Equal(true, verifyChunkMessagesMatchesRecordMockCalled_process_unassigned_chunks)
+	suite.True(sendChunksToChannelMockCalled_process_unassigned_chunks)
+	suite.True(verifyChunkMessagesMatchesRecordMockCalled_process_unassigned_chunks)
 	suite.Equal(4*(numChunks+1), len(AllChunksCalled)) // 4 data maps so 4 chunks have been added
 
 	/* This test is verifying that the chunks belonging to particular sessions were sent
@@ -124,10 +124,10 @@ func (suite *JobsSuite) Test_ProcessUnassignedChunks() {
 		}
 	}
 
-	suite.Equal(true, genHashMapIdx["abcdeff4"][0] > genHashMapIdx["abcdeff4"][len(genHashMapIdx["abcdeff4"])-1])
-	suite.Equal(true, genHashMapIdx["abcdeff2"][0] > genHashMapIdx["abcdeff2"][len(genHashMapIdx["abcdeff2"])-1])
-	suite.Equal(true, genHashMapIdx["abcdeff1"][0] < genHashMapIdx["abcdeff1"][len(genHashMapIdx["abcdeff1"])-1])
-	suite.Equal(true, genHashMapIdx["abcdeff3"][0] < genHashMapIdx["abcdeff3"][len(genHashMapIdx["abcdeff3"])-1])
+	suite.True(genHashMapIdx["abcdeff4"][0] > genHashMapIdx["abcdeff4"][len(genHashMapIdx["abcdeff4"])-1])
+	suite.True(genHashMapIdx["abcdeff2"][0] > genHashMapIdx["abcdeff2"][len(genHashMapIdx["abcdeff2"])-1])
+	suite.True(genHashMapIdx["abcdeff1"][0] < genHashMapIdx["abcdeff1"][len(genHashMapIdx["abcdeff1"])-1])
+	suite.True(genHashMapIdx["abcdeff3"][0] < genHashMapIdx["abcdeff3"][len(genHashMapIdx["abcdeff3"])-1])
 
 	suite.Equal(0, genHashMapOrder["abcdeff4"])
 	suite.Equal(1, genHashMapOrder["abcdeff2"])
@@ -202,7 +202,7 @@ func (suite *JobsSuite) Test_HandleTreasureChunks() {
 		suite.NotEqual(20, chunk.ChunkIdx)
 	}
 
-	suite.Equal(true, findTransactionsMockCalled_process_unassigned_chunks)
+	suite.True(findTransactionsMockCalled_process_unassigned_chunks)
 	suite.Equal(len(dataMaps)-2, len(chunksToAttach))
 	suite.Equal(1, len(treasureChunks))
 	suite.Equal(15, treasureChunks[0].ChunkIdx)
@@ -354,11 +354,11 @@ func (suite *JobsSuite) Test_SkipVerificationOfFirstChunks_Beta() {
 	restMaxIdx = lenOfRestOfChunks - 1
 
 	for _, chunk := range skipVerifyChunks {
-		suite.Equal(true, chunk.ChunkIdx >= skipVerifyMinIdx &&
+		suite.True(chunk.ChunkIdx >= skipVerifyMinIdx &&
 			chunk.ChunkIdx <= skipVerifyMaxIdx)
 	}
 	for _, chunk := range restOfChunks {
-		suite.Equal(true, chunk.ChunkIdx >= restMinIdx &&
+		suite.True(chunk.ChunkIdx >= restMinIdx &&
 			chunk.ChunkIdx <= restMaxIdx)
 	}
 }
@@ -402,11 +402,11 @@ func (suite *JobsSuite) Test_SkipVerificationOfFirstChunks_Alpha() {
 	restMaxIdx = numChunks
 
 	for _, chunk := range skipVerifyChunks {
-		suite.Equal(true, chunk.ChunkIdx >= skipVerifyMinIdx &&
+		suite.True(chunk.ChunkIdx >= skipVerifyMinIdx &&
 			chunk.ChunkIdx <= skipVerifyMaxIdx)
 	}
 	for _, chunk := range restOfChunks {
-		suite.Equal(true, chunk.ChunkIdx >= restMinIdx &&
+		suite.True(chunk.ChunkIdx >= restMinIdx &&
 			chunk.ChunkIdx <= restMaxIdx)
 	}
 }

--- a/jobs/verify_data_maps_test.go
+++ b/jobs/verify_data_maps_test.go
@@ -42,7 +42,7 @@ func (suite *JobsSuite) Test_VerifyDataMaps() {
 	jobs.VerifyDataMaps(IotaMock, jobs.PrometheusWrapper)
 
 	// verify the mock methods were called
-	suite.Equal(true, verifyChunkMessagesMatchesRecordMockCalled_verify)
+	suite.True(verifyChunkMessagesMatchesRecordMockCalled_verify)
 
 	// verify that the data maps that didn't match the tangle were set to an error state
 	allDataMaps = []models.DataMap{}

--- a/models/broker_broker_transactions_test.go
+++ b/models/broker_broker_transactions_test.go
@@ -34,7 +34,7 @@ func (suite *ModelSuite) Test_InitialBrokerBrokerTransactionCreation() {
 
 	vErr, err := suite.DB.ValidateAndCreate(&brokerTx)
 	suite.Nil(err)
-	suite.Equal(0, len(vErr.Errors))
+	suite.False(vErr.HasAny())
 
 	brokerTxs := returnAllBrokerBrokerTxs(suite)
 	suite.Equal(1, len(brokerTxs))
@@ -75,7 +75,7 @@ func (suite *ModelSuite) Test_NewBrokerBrokerTransaction() {
 
 	vErr, err := u.StartUploadSession()
 	suite.Nil(err)
-	suite.Equal(0, len(vErr.Errors))
+	suite.False(vErr.HasAny())
 
 	uSession := models.UploadSession{}
 	suite.DB.Where("genesis_hash = ?", genHash).First(&uSession)
@@ -284,7 +284,7 @@ func (suite *ModelSuite) Test_SetUploadSessionToPaid() {
 
 	vErr, err := u.StartUploadSession()
 	suite.Nil(err)
-	suite.Equal(0, len(vErr.Errors))
+	suite.False(vErr.HasAny())
 
 	uSession := models.UploadSession{}
 	suite.DB.Where("genesis_hash = ?", genHash).First(&uSession)
@@ -344,7 +344,7 @@ func generateBrokerBrokerTransactions(suite *ModelSuite,
 
 		vErr, err := suite.DB.ValidateAndCreate(&brokerTx)
 		suite.Nil(err)
-		suite.Equal(0, len(vErr.Errors))
+		suite.False(vErr.HasAny())
 	}
 }
 

--- a/models/completed_uploads_test.go
+++ b/models/completed_uploads_test.go
@@ -223,12 +223,12 @@ func testNewCompletedUpload(suite *ModelSuite) {
 
 	completedUploads := []models.CompletedUpload{}
 	err = suite.DB.All(&completedUploads)
-	suite.Equal(nil, err)
+	suite.Nil(err)
 
 	suite.Equal(2, len(completedUploads))
 
 	for _, completedUpload := range completedUploads {
-		suite.Equal(true, completedUpload.GenesisHash == "abcdeff1" ||
+		suite.True(completedUpload.GenesisHash == "abcdeff1" ||
 			completedUpload.GenesisHash == "abcdeff2")
 		if completedUpload.GenesisHash == "abcdeff1" {
 			suite.Equal("SOME_BETA_ETH_ADDRESS1", completedUpload.ETHAddr)
@@ -393,7 +393,7 @@ func testDeleteCompletedClaims(suite *ModelSuite) {
 	//should be 10 of these
 	completedUploads := []models.CompletedUpload{}
 	err := suite.DB.All(&completedUploads)
-	suite.Equal(nil, err)
+	suite.Nil(err)
 	suite.Equal(10, len(completedUploads))
 
 	models.DeleteCompletedClaims()
@@ -401,6 +401,6 @@ func testDeleteCompletedClaims(suite *ModelSuite) {
 	//should be 9 now
 	completedUploads = []models.CompletedUpload{}
 	err = suite.DB.All(&completedUploads)
-	suite.Equal(nil, err)
+	suite.Nil(err)
 	suite.Equal(9, len(completedUploads))
 }

--- a/models/data_maps_test.go
+++ b/models/data_maps_test.go
@@ -99,7 +99,7 @@ func (suite *ModelSuite) Test_CreateTreasurePayload() {
 			currentHash = oyster_utils.HashHex(currentHash, sha3.New256())
 			result := oyster_utils.Decrypt(currentHash, hex.EncodeToString(payloadInBytes), tc.sha256Hash)
 			if result != nil {
-				suite.Equal(true, strings.Contains(hex.EncodeToString(result), fmt.Sprint(models.TreasurePrefix)))
+				suite.True(strings.Contains(hex.EncodeToString(result), fmt.Sprint(models.TreasurePrefix)))
 				suite.Equal(hex.EncodeToString(result)[len(models.TreasurePrefix):], tc.ethPrivateSeed)
 				matchesFound++
 			}
@@ -132,13 +132,13 @@ func (suite *ModelSuite) Test_GetUnassignedGenesisHashes() {
 	genHash3 := []models.DataMap{} // all unassigned
 	genHash4 := []models.DataMap{} // all error
 	err = suite.DB.Where("genesis_hash = ?", "abcdeff1").All(&genHash1)
-	suite.Equal(err, nil)
+	suite.Nil(err)
 	err = suite.DB.Where("genesis_hash = ?", "abcdeff2").All(&genHash2)
-	suite.Equal(err, nil)
+	suite.Nil(err)
 	err = suite.DB.Where("genesis_hash = ?", "abcdeff3").All(&genHash3)
-	suite.Equal(err, nil)
+	suite.Nil(err)
 	err = suite.DB.Where("genesis_hash = ?", "abcdeff4").All(&genHash4)
-	suite.Equal(err, nil)
+	suite.Nil(err)
 
 	genHash1[1].Status = models.Unassigned
 	suite.DB.ValidateAndSave(&genHash1[1])
@@ -157,7 +157,7 @@ func (suite *ModelSuite) Test_GetUnassignedGenesisHashes() {
 	}
 
 	genHashes, err := models.GetUnassignedGenesisHashes()
-	suite.Equal(err, nil)
+	suite.Nil(err)
 	suite.Equal(4, len(genHashes))
 
 	for _, genHash := range genHashes {
@@ -191,13 +191,13 @@ func (suite *ModelSuite) Test_GetUnassignedChunks() {
 	genHash3 := []models.DataMap{} // all unassigned
 	genHash4 := []models.DataMap{} // all error
 	err = suite.DB.Where("genesis_hash = ?", "abcdeff1").All(&genHash1)
-	suite.Equal(err, nil)
+	suite.Nil(err)
 	err = suite.DB.Where("genesis_hash = ?", "abcdeff2").All(&genHash2)
-	suite.Equal(err, nil)
+	suite.Nil(err)
 	err = suite.DB.Where("genesis_hash = ?", "abcdeff3").All(&genHash3)
-	suite.Equal(err, nil)
+	suite.Nil(err)
 	err = suite.DB.Where("genesis_hash = ?", "abcdeff4").All(&genHash4)
-	suite.Equal(err, nil)
+	suite.Nil(err)
 
 	genHash1[1].Status = models.Unassigned
 	suite.DB.ValidateAndSave(&genHash1[1])
@@ -216,7 +216,7 @@ func (suite *ModelSuite) Test_GetUnassignedChunks() {
 	}
 
 	unassignedChunks, err := models.GetUnassignedChunks()
-	suite.Equal(err, nil)
+	suite.Nil(err)
 
 	for _, unassignedChunk := range unassignedChunks {
 		if unassignedChunk.GenesisHash == "abcdeff5" {
@@ -429,13 +429,13 @@ func (suite *ModelSuite) Test_AttachUnassignedChunksToGenHashMap() {
 	//genHash3 := []models.DataMap{}
 	//genHash4 := []models.DataMap{}
 	//err := suite.DB.Where("genesis_hash = ?", "abcdeff1").All(&genHash1)
-	//suite.Equal(err, nil)
+	//suite.Nil(err)
 	//err = suite.DB.Where("genesis_hash = ?", "abcdeff2").All(&genHash2)
-	//suite.Equal(err, nil)
+	//suite.Nil(err)
 	//err = suite.DB.Where("genesis_hash = ?", "abcdeff3").All(&genHash3)
-	//suite.Equal(err, nil)
+	//suite.Nil(err)
 	//err = suite.DB.Where("genesis_hash = ?", "abcdeff4").All(&genHash4)
-	//suite.Equal(err, nil)
+	//suite.Nil(err)
 	//
 	//genHash1[0].Status = models.Unassigned
 	//genHash1[1].Status = models.Unassigned
@@ -458,7 +458,7 @@ func (suite *ModelSuite) Test_AttachUnassignedChunksToGenHashMap() {
 	//}
 	//
 	//genHashes, err := models.GetUnassignedGenesisHashes()
-	//suite.Equal(err, nil)
+	//suite.Nil(err)
 	//suite.Equal(4, len(genHashes))
 	//
 	//hashAndTypeMap, err := models.AttachUnassignedChunksToGenHashMap(genHashes)

--- a/models/treasure_test.go
+++ b/models/treasure_test.go
@@ -23,7 +23,7 @@ func (suite *ModelSuite) Test_GetTreasuresToBuryByPRLStatus() {
 	allTreasures, err := models.GetAllTreasuresToBury()
 	suite.Nil(err)
 
-	suite.Equal(true, len(allTreasures) > len(waitingForPRL))
+	suite.True(len(allTreasures) > len(waitingForPRL))
 }
 
 func (suite *ModelSuite) Test_GetTreasuresToBuryByPRLStatusAndUpdateTime() {
@@ -84,10 +84,10 @@ func (suite *ModelSuite) Test_EncryptAndDecryptEthPrivateKey() {
 	}
 
 	suite.DB.ValidateAndCreate(&treasureToBury)
-	suite.Equal(false, ethKey == treasureToBury.ETHKey)
+	suite.False(ethKey == treasureToBury.ETHKey)
 
 	decryptedKey := treasureToBury.DecryptTreasureEthKey()
-	suite.Equal(true, ethKey == decryptedKey)
+	suite.True(ethKey == decryptedKey)
 }
 
 func generateTreasuresToBuryOfEachStatus(suite *ModelSuite, numToCreateOfEachStatus int) {

--- a/models/upload_sessions_test.go
+++ b/models/upload_sessions_test.go
@@ -141,10 +141,10 @@ func (suite *ModelSuite) Test_TreasureMapGetterAndSetter() {
 
 	for _, entry := range treasureIdxMap {
 		_, ok := t[entry.Idx]
-		suite.Equal(true, ok)
-		suite.Equal(t[entry.Idx].Sector, entry.Sector)
-		suite.Equal(t[entry.Idx].Key, entry.Key)
-		suite.Equal(t[entry.Idx].Idx, entry.Idx)
+		suite.True(ok)
+		suite.Equal(entry.Sector, t[entry.Idx].Sector)
+		suite.Equal(entry.Key, t[entry.Idx].Key)
+		suite.Equal(entry.Idx, t[entry.Idx].Idx)
 	}
 }
 
@@ -233,7 +233,7 @@ func (suite *ModelSuite) Test_MakeTreasureIdxMap() {
 	defer oyster_utils.ResetBrokerMode()
 	oyster_utils.SetBrokerMode(oyster_utils.TestModeDummyTreasure)
 
-    sectorSize := 100
+	sectorSize := 100
 
 	genHash := "abcdef"
 	numChunks := 250
@@ -268,9 +268,9 @@ func (suite *ModelSuite) Test_MakeTreasureIdxMap() {
 	suite.Equal(1, treasureIdxMap[1].Sector)
 	suite.Equal(2, treasureIdxMap[2].Sector)
 
-    // This will break anytime we change the hashing method.
-    suite.Equal(68, treasureIdxMap[0].Idx)
-    suite.Equal(148, treasureIdxMap[1].Idx)
+	// This will break anytime we change the hashing method.
+	suite.Equal(68, treasureIdxMap[0].Idx)
+	suite.Equal(148, treasureIdxMap[1].Idx)
 	suite.Equal(210, treasureIdxMap[2].Idx)
 }
 
@@ -279,7 +279,7 @@ func (suite *ModelSuite) Test_GetTreasureIndexes() {
 	defer oyster_utils.SetBrokerMode(oyster_utils.ProdMode)
 	oyster_utils.SetBrokerMode(oyster_utils.TestModeDummyTreasure)
 
-    sectorSize:= 100
+	sectorSize := 100
 
 	genHash := "abcdef"
 	numChunks := 250
@@ -501,19 +501,19 @@ func (suite *ModelSuite) Test_PaymentStatus() {
 	u := models.UploadSession{}
 
 	u.PaymentStatus = models.PaymentStatusConfirmed
-	suite.Equal(u.GetPaymentStatus(), "confirmed")
+	suite.Equal("confirmed", u.GetPaymentStatus())
 
 	u.PaymentStatus = models.PaymentStatusInvoiced
-	suite.Equal(u.GetPaymentStatus(), "invoiced")
+	suite.Equal("invoiced", u.GetPaymentStatus())
 
 	u.PaymentStatus = models.PaymentStatusPending
-	suite.Equal(u.GetPaymentStatus(), "pending")
+	suite.Equal("pending", u.GetPaymentStatus())
 
 	u.PaymentStatus = 100
-	suite.Equal(u.GetPaymentStatus(), "error")
+	suite.Equal("error", u.GetPaymentStatus())
 
 	u.PaymentStatus = models.PaymentStatusError
-	suite.Equal(u.GetPaymentStatus(), "error")
+	suite.Equal("error", u.GetPaymentStatus())
 }
 
 func (ms *ModelSuite) Test_SetBrokerTransactionToPaid() {


### PR DESCRIPTION
Use suite.Equal(expected, actual) format in all unit test.
Use suite.Nil(err)
Use suite.False(vErr.HasAny())
Use suite.True(foo) for suite.Equal(true, foo) or suite.False(foo) for suite.False(foo)