### PR TITLE
Do not accept new uploads if a deploy is in progress

### DIFF
--- a/actions/upload_sessions.go
+++ b/actions/upload_sessions.go
@@ -82,6 +82,14 @@ func init() {
 
 // Create creates an upload session.
 func (usr *UploadSessionResource) Create(c buffalo.Context) error {
+
+	if os.Getenv("DEPLOY_IN_PROGRESS") == "true" {
+		err := errors.New("Deployment in progress.  Try again later")
+		fmt.Println(err)
+		c.Error(400, err)
+		return err
+	}
+
 	start := PrometheusWrapper.TimeNow()
 	defer PrometheusWrapper.HistogramSeconds(PrometheusWrapper.HistogramUploadSessionResourceCreate, start)
 


### PR DESCRIPTION
Checks an .env variable to see if a dev has set DEPLOY_IN_PROGRESS to true, and if so, reject new uploads while deploy is happening.