### PR TITLE
add endpoint for checking broker status

### DIFF
--- a/actions/app.go
+++ b/actions/app.go
@@ -99,9 +99,9 @@ func App() *buffalo.App {
 		treasures := TreasuresResource{}
 		apiV2.POST("treasures", treasures.VerifyAndClaim)
 
-		// Availability
+		// Status
 		statusResource := StatusResource{}
-		apiV2.GET("check-availability", statusResource.CheckAvailability)
+		apiV2.GET("status", statusResource.CheckStatus)
 	}
 
 	return app

--- a/actions/app.go
+++ b/actions/app.go
@@ -12,9 +12,9 @@ import (
 	"github.com/oysterprotocol/brokernode/jobs"
 	"github.com/oysterprotocol/brokernode/models"
 	"github.com/oysterprotocol/brokernode/services"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/rs/cors"
 	"github.com/unrolled/secure"
-	"github.com/prometheus/client_golang/prometheus"
 )
 
 // ENV is used to help switch settings based on where the
@@ -98,6 +98,10 @@ func App() *buffalo.App {
 		// Treasures
 		treasures := TreasuresResource{}
 		apiV2.POST("treasures", treasures.VerifyAndClaim)
+
+		// Availability
+		statusResource := StatusResource{}
+		apiV2.GET("check-availability", statusResource.CheckAvailability)
 	}
 
 	return app

--- a/actions/status.go
+++ b/actions/status.go
@@ -1,0 +1,28 @@
+package actions
+
+import (
+	"github.com/gobuffalo/buffalo"
+	"os"
+)
+
+type StatusResource struct {
+	buffalo.Resource
+}
+
+// Response structs
+type checkAvailabilityRes struct {
+	Available bool `json:"available"`
+}
+
+/*CheckAvailability checks conditions to determine if the brokernode is available.
+We can add more conditions to this method as needed*/
+func (status *StatusResource) CheckAvailability(c buffalo.Context) error {
+
+	available := os.Getenv("DEPLOY_IN_PROGRESS") != "true"
+
+	res := checkAvailabilityRes{
+		Available: available,
+	}
+
+	return c.Render(200, r.JSON(res))
+}

--- a/actions/status.go
+++ b/actions/status.go
@@ -5,22 +5,23 @@ import (
 	"os"
 )
 
+/*StatusResource is a resource for the status endpoint*/
 type StatusResource struct {
 	buffalo.Resource
 }
 
 // Response structs
-type checkAvailabilityRes struct {
+type checkStatusRes struct {
 	Available bool `json:"available"`
 }
 
-/*CheckAvailability checks conditions to determine if the brokernode is available.
+/*CheckStatus checks conditions to determine if the brokernode is available.
 We can add more conditions to this method as needed*/
-func (status *StatusResource) CheckAvailability(c buffalo.Context) error {
+func (status *StatusResource) CheckStatus(c buffalo.Context) error {
 
 	available := os.Getenv("DEPLOY_IN_PROGRESS") != "true"
 
-	res := checkAvailabilityRes{
+	res := checkStatusRes{
 		Available: available,
 	}
 

--- a/actions/status_test.go
+++ b/actions/status_test.go
@@ -1,0 +1,21 @@
+package actions
+
+import (
+	"encoding/json"
+	"io/ioutil"
+)
+
+func (suite *ActionSuite) Test_CheckAvailability() {
+	res := suite.JSON("/api/v2/check-availability").Get()
+
+	suite.Equal(200, res.Code)
+
+	// Parse response
+	resParsed := checkAvailabilityRes{}
+	bodyBytes, err := ioutil.ReadAll(res.Body)
+	suite.Nil(err)
+	err = json.Unmarshal(bodyBytes, &resParsed)
+	suite.Nil(err)
+
+	suite.Equal(true, resParsed.Available == true || resParsed.Available == false)
+}

--- a/actions/status_test.go
+++ b/actions/status_test.go
@@ -5,13 +5,13 @@ import (
 	"io/ioutil"
 )
 
-func (suite *ActionSuite) Test_CheckAvailability() {
-	res := suite.JSON("/api/v2/check-availability").Get()
+func (suite *ActionSuite) Test_CheckStatus() {
+	res := suite.JSON("/api/v2/status").Get()
 
 	suite.Equal(200, res.Code)
 
 	// Parse response
-	resParsed := checkAvailabilityRes{}
+	resParsed := checkStatusRes{}
 	bodyBytes, err := ioutil.ReadAll(res.Body)
 	suite.Nil(err)
 	err = json.Unmarshal(bodyBytes, &resParsed)


### PR DESCRIPTION
Adds an endpoint `/api/v2/check-availability` that will return true or false based on whether the brokers's DEPLOY_IN_PROGRESS env var is set to true.  We can add more checks to this method in the future if we need to.