### PR TITLE
Optimize the DB query

### DIFF
--- a/models/upload_sessions.go
+++ b/models/upload_sessions.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"math"
 	"math/big"
+	"strings"
 	"time"
 
 	"github.com/gobuffalo/pop"
@@ -312,29 +313,56 @@ func (u *UploadSession) GetTreasureIndexes() ([]int, error) {
 
 func (u *UploadSession) BulkMarkDataMapsAsUnassigned() error {
 	var err error
+	var ids []string
+	var dm []DataMap
+
+	err = DB.RawQuery("SELECT id FROM data_maps WHERE genesis_hash = ? AND status = ? AND message != ? AND msg_status = ?",
+		u.GenesisHash,
+		Pending,
+		DataMap{}.Message,
+		MsgStatusUnmigrated).All(&dm)
+	oyster_utils.LogIfError(err, nil)
+
+	for _, v := range dm {
+		ids = append(ids, v.ID.String())
+	}
+	err = nil
+
+	idsString := strings.Join(ids, ", ")
+
 	for i := 0; i < oyster_utils.MAX_NUMBER_OF_SQL_RETRY; i++ {
+		if len(idsString) == 0 {
+			break
+		}
 		err = DB.RawQuery("UPDATE data_maps SET status = ? "+
-			"WHERE genesis_hash = ? AND status = ? AND message != ? AND msg_status = ?",
+			"WHERE id IN(?)",
 			Unassigned,
-			u.GenesisHash,
-			Pending,
-			DataMap{}.Message,
-			MsgStatusUnmigrated).All(&[]DataMap{})
+			idsString).All(&[]DataMap{})
 		if err == nil {
 			break
 		}
 	}
 	oyster_utils.LogIfError(err, map[string]interface{}{"MaxRetry": oyster_utils.MAX_NUMBER_OF_SQL_RETRY})
+	err = nil
+
+	err = DB.RawQuery("SELECT id FROM data_maps WHERE genesis_hash = ? AND status = ? AND (msg_status = ? OR msg_status = ?)",
+		u.GenesisHash,
+		Pending,
+		MsgStatusNotUploaded,
+		MsgStatusUploadedHaveNotEncoded).All(&dm)
+	oyster_utils.LogIfError(err, nil)
+
+	for _, v := range dm {
+		ids = append(ids, v.ID.String())
+	}
+	idsString = strings.Join(ids, ", ")
 
 	err = nil
 	for i := 0; i < oyster_utils.MAX_NUMBER_OF_SQL_RETRY; i++ {
 		err = DB.RawQuery("UPDATE data_maps SET status = ? "+
-			"WHERE genesis_hash = ? AND status = ? AND (msg_status = ? OR msg_status = ?)",
+			"WHERE id IN(?)",
 			Unassigned,
-			u.GenesisHash,
-			Pending,
-			MsgStatusUploadedNoNeedEncode,
-			MsgStatusUploadedHaveNotEncoded).All(&[]DataMap{})
+			idsString).All(&[]DataMap{})
 		if err == nil {
 			break
 		}

--- a/models/upload_sessions.go
+++ b/models/upload_sessions.go
@@ -348,7 +348,7 @@ func (u *UploadSession) BulkMarkDataMapsAsUnassigned() error {
 	err = DB.RawQuery("SELECT id FROM data_maps WHERE genesis_hash = ? AND status = ? AND (msg_status = ? OR msg_status = ?)",
 		u.GenesisHash,
 		Pending,
-		MsgStatusNotUploaded,
+		MsgStatusUploadedNoNeedEncode,
 		MsgStatusUploadedHaveNotEncoded).All(&dm)
 	oyster_utils.LogIfError(err, nil)
 

--- a/models/upload_sessions_test.go
+++ b/models/upload_sessions_test.go
@@ -580,8 +580,9 @@ func (suite *ModelSuite) Test_BulkMarkDataMapsAsUnassigned_BeforeMigration() {
 		Message:     "abc",
 		MsgStatus:   models.MsgStatusUnmigrated,
 	}
+
 	suite.Nil(
-		suite.DB.RawQuery(fmt.Sprintf("INSERT INTO data_maps (%s) VALUES %s",
+		suite.DB.RawQuery(fmt.Sprintf("INSERT INTO data_maps (%s) VALUES (%s)",
 			columnsName, dbOperation.GetNewInsertedValue(dataMap))).All(&[]models.DataMap{}))
 
 	dataMap = models.DataMap{
@@ -594,7 +595,7 @@ func (suite *ModelSuite) Test_BulkMarkDataMapsAsUnassigned_BeforeMigration() {
 		MsgStatus:   models.MsgStatusUnmigrated,
 	}
 	suite.Nil(
-		suite.DB.RawQuery(fmt.Sprintf("INSERT INTO data_maps (%s) VALUES %s",
+		suite.DB.RawQuery(fmt.Sprintf("INSERT INTO data_maps (%s) VALUES (%s)",
 			columnsName, dbOperation.GetNewInsertedValue(dataMap))).All(&[]models.DataMap{}))
 
 	dm := []models.DataMap{}

--- a/models/upload_sessions_test.go
+++ b/models/upload_sessions_test.go
@@ -568,35 +568,35 @@ func (suite *ModelSuite) Test_SetBrokerTransactionToPaid() {
 
 func (suite *ModelSuite) Test_BulkMarkDataMapsAsUnassigned_BeforeMigration() {
 	genesisHash := "beforeMigration"
-	v, e := suite.DB.ValidateAndCreate(&models.DataMap{
+
+	vErr, err := suite.DB.ValidateAndCreate(&models.DataMap{
 		GenesisHash: genesisHash,
 		Status:      models.Pending,
 		ChunkIdx:    0,
 		Hash:        "0",
+		MsgID:       "",
 		Message:     "abc",
 		MsgStatus:   models.MsgStatusUnmigrated,
 	})
-	suite.Nil(e)
-	suite.Nil(v.Errors())
-	suite.False(v.HasAny())
+	suite.Nil(err)
+	suite.False(vErr.HasAny())
 
-	v, e = suite.DB.ValidateAndCreate(&models.DataMap{
+	vErr, err = suite.DB.ValidateAndCreate(&models.DataMap{
 		GenesisHash: genesisHash,
 		Status:      models.Pending,
 		ChunkIdx:    1,
 		Hash:        "1",
+		MsgID:       "",
 		Message:     "123",
 		MsgStatus:   models.MsgStatusUnmigrated,
 	})
-	suite.Nil(e)
-	suite.False(v.HasAny())
+	suite.Nil(err)
+	suite.False(vErr.HasAny())
 
 	dm := []models.DataMap{}
-	err := suite.DB.RawQuery("SELECT * FROM data_maps WHERE status = ? AND genesis_hash = ?",
+	suite.Nil(suite.DB.RawQuery("SELECT * FROM data_maps WHERE status = ? AND genesis_hash = ?",
 		models.Pending,
-		genesisHash).All(&dm)
-	fmt.Println(err)
-	suite.Nil(err)
+		genesisHash).All(&dm))
 	suite.Equal(2, len(dm))
 
 	u := models.UploadSession{
@@ -619,6 +619,7 @@ func (suite *ModelSuite) Test_BulkMarkDataMapsAsUnassigned_AfterMigration() {
 		GenesisHash: genesisHash,
 		ChunkIdx:    0,
 		Hash:        "0",
+		MsgID:       "msg_0",
 		Status:      models.Pending,
 		MsgStatus:   models.MsgStatusUploadedNoNeedEncode,
 	})
@@ -627,6 +628,7 @@ func (suite *ModelSuite) Test_BulkMarkDataMapsAsUnassigned_AfterMigration() {
 		GenesisHash: genesisHash,
 		ChunkIdx:    1,
 		Hash:        "1",
+		MsgID:       "msg_1",
 		Status:      models.Pending,
 		MsgStatus:   models.MsgStatusUploadedHaveNotEncoded,
 	})

--- a/models/upload_sessions_test.go
+++ b/models/upload_sessions_test.go
@@ -579,7 +579,7 @@ func (suite *ModelSuite) Test_BulkMarkDataMapsAsUnassigned_BeforeMigration() {
 	suite.Nil(e)
 	suite.False(v.HasAny())
 
-	suite.DB.ValidateAndCreate(&models.DataMap{
+	v, e = suite.DB.ValidateAndCreate(&models.DataMap{
 		GenesisHash: genesisHash,
 		Status:      models.Pending,
 		ChunkIdx:    1,
@@ -587,6 +587,8 @@ func (suite *ModelSuite) Test_BulkMarkDataMapsAsUnassigned_BeforeMigration() {
 		Message:     "123",
 		MsgStatus:   models.MsgStatusUnmigrated,
 	})
+	suite.Nil(e)
+	suite.False(v.HasAny())
 
 	dm := []models.DataMap{}
 	err := suite.DB.RawQuery("SELECT * FROM data_maps WHERE status = ? AND genesis_hash = ?",

--- a/models/upload_sessions_test.go
+++ b/models/upload_sessions_test.go
@@ -582,7 +582,7 @@ func (suite *ModelSuite) Test_BulkMarkDataMapsAsUnassigned_BeforeMigration() {
 	}
 	suite.Nil(
 		suite.DB.RawQuery(fmt.Sprintf("INSERT INTO data_maps (%s) VALUES %s",
-			columnsName, dbOperation.GetNewInsertedValue(dataMap))).All(&[]DataMap{}))
+			columnsName, dbOperation.GetNewInsertedValue(dataMap))).All(&[]models.DataMap{}))
 
 	dataMap = models.DataMap{
 		GenesisHash: genesisHash,
@@ -595,7 +595,7 @@ func (suite *ModelSuite) Test_BulkMarkDataMapsAsUnassigned_BeforeMigration() {
 	}
 	suite.Nil(
 		suite.DB.RawQuery(fmt.Sprintf("INSERT INTO data_maps (%s) VALUES %s",
-			columnsName, dbOperation.GetNewInsertedValue(dataMap))).All(&[]DataMap{}))
+			columnsName, dbOperation.GetNewInsertedValue(dataMap))).All(&[]models.DataMap{}))
 
 	dm := []models.DataMap{}
 	suite.Nil(

--- a/models/upload_sessions_test.go
+++ b/models/upload_sessions_test.go
@@ -577,6 +577,7 @@ func (suite *ModelSuite) Test_BulkMarkDataMapsAsUnassigned_BeforeMigration() {
 		MsgStatus:   models.MsgStatusUnmigrated,
 	})
 	suite.Nil(e)
+	suite.Nil(v.Errors())
 	suite.False(v.HasAny())
 
 	v, e = suite.DB.ValidateAndCreate(&models.DataMap{

--- a/models/upload_sessions_test.go
+++ b/models/upload_sessions_test.go
@@ -579,11 +579,11 @@ func (suite *ModelSuite) Test_BulkMarkDataMapsAsUnassigned_BeforeMigration() {
 		MsgID:       "msg_0",
 		Message:     "abc",
 		MsgStatus:   models.MsgStatusUnmigrated,
-	})
+	}
 	suite.Nil(
-		suite.DB.RawQuery(fmt.Sprintf("INSERT INTO data_maps (%s) VALUES %s", 
+		suite.DB.RawQuery(fmt.Sprintf("INSERT INTO data_maps (%s) VALUES %s",
 			columnsName, dbOperation.GetNewInsertedValue(dataMap))).All(&[]DataMap{}))
-	
+
 	dataMap = models.DataMap{
 		GenesisHash: genesisHash,
 		Status:      models.Pending,
@@ -592,9 +592,9 @@ func (suite *ModelSuite) Test_BulkMarkDataMapsAsUnassigned_BeforeMigration() {
 		MsgID:       "msg_1",
 		Message:     "123",
 		MsgStatus:   models.MsgStatusUnmigrated,
-	})
+	}
 	suite.Nil(
-		suite.DB.RawQuery(fmt.Sprintf("INSERT INTO data_maps (%s) VALUES %s", 
+		suite.DB.RawQuery(fmt.Sprintf("INSERT INTO data_maps (%s) VALUES %s",
 			columnsName, dbOperation.GetNewInsertedValue(dataMap))).All(&[]DataMap{}))
 
 	dm := []models.DataMap{}


### PR DESCRIPTION
Using UPDATE with WHERE will lock the entire table and prevent any further operation.
UPDATE with WHERE and SELECT will lead to error from DB.

As a result, break the query into 2 parts. SELECT and then UPDATE