### PR TITLE
Async

### DIFF
--- a/actions/upload_sessions.go
+++ b/actions/upload_sessions.go
@@ -394,67 +394,58 @@ func ProcessAndStoreChunkData(chunks []chunkReq, genesisHash string, treasureIdx
 	// Query data_maps to get models.DataMap based on require chunk.
 	var dms []models.DataMap
 	//rawQuery := fmt.Sprintf("SELECT * FROM data_maps WHERE %s", strings.Join(sqlWhereClosures, " OR "))
+	err := models.DB.RawQuery(
+		"SELECT * FROM data_maps WHERE genesis_hash = ? AND chunk_idx >= ? AND chunk_idx <= ?",
+		genesisHash, minChunkIdx, maxChunkIdx).All(&dms)
+	oyster_utils.LogIfError(err, nil)
 
-	for {
-		err := models.DB.RawQuery(
-			"SELECT * FROM data_maps WHERE genesis_hash = ? AND chunk_idx >= ? AND chunk_idx <= ?",
-			genesisHash, minChunkIdx, maxChunkIdx).All(&dms)
-		oyster_utils.LogIfError(err, nil)
+	dmsMap := convertToSQLKeyedMapForDataMap(dms)
 
-		if len(dms) < len(chunks) {
-			time.Sleep(3 * time.Second)
+	// Create Update operation for data_maps table.
+	dbOperation, _ := oyster_utils.CreateDbUpdateOperation(&models.DataMap{})
+	batchSetKvMap := services.KVPairs{} // Store chunk.Data into KVStore
+	var updatedDms []string
+	for key, chunk := range chunksMap {
+		dm, hasKey := dmsMap[key]
+		if !hasKey {
 			continue
 		}
 
-		dmsMap := convertToSQLKeyedMapForDataMap(dms)
-
-		// Create Update operation for data_maps table.
-		dbOperation, _ := oyster_utils.CreateDbUpdateOperation(&models.DataMap{})
-		batchSetKvMap := services.KVPairs{} // Store chunk.Data into KVStore
-		var updatedDms []string
-		for key, chunk := range chunksMap {
-			dm, hasKey := dmsMap[key]
-			if !hasKey {
-				continue
-			}
-
-			if dm.MsgID == "" {
-				oyster_utils.LogIfError(errors.New("DataMap was not stored into data_maps table and MsgID is empty"), nil)
-				break
-			}
-
-			if chunk.Hash == dm.GenesisHash {
-				if services.IsKvStoreEnabled() {
-					batchSetKvMap[dm.MsgID] = chunk.Data
-					dm.Message = "" // Remove previous Message data.
-					dm.MsgStatus = models.MsgStatusUploadedHaveNotEncoded
-				} else {
-					// TODO:pzhao, remove this and this should not be called.
-					message, err := oyster_utils.ChunkMessageToTrytesWithStopper(chunk.Data)
-					if err != nil {
-						panic(err.Error())
-					}
-					dm.Message = string(message)
-					dm.MsgStatus = models.MsgStatusUploadedNoNeedEncode
-				}
-
-				if oyster_utils.BrokerMode == oyster_utils.TestModeNoTreasure {
-					dm.Status = models.Unassigned
-				}
-				vErr, _ := dm.Validate(nil)
-				oyster_utils.LogIfValidationError("Unable to create data_maps for batch insertion.", vErr, nil)
-				if !vErr.HasAny() {
-					updatedDms = append(updatedDms, fmt.Sprintf("(%s)", dbOperation.GetUpdatedValue(dm)))
-				}
-			}
+		if dm.MsgID == "" {
+			oyster_utils.LogIfError(errors.New("DataMap was not stored into data_maps table and MsgID is empty"), nil)
+			break
 		}
 
-		err = batchUpsertDataMaps(updatedDms, dbOperation.GetColumns())
-		// Save Message field into KVStore
-		if err == nil && services.IsKvStoreEnabled() {
-			services.BatchSet(&batchSetKvMap)
+		if chunk.Hash == dm.GenesisHash {
+			if services.IsKvStoreEnabled() {
+				batchSetKvMap[dm.MsgID] = chunk.Data
+				dm.Message = "" // Remove previous Message data.
+				dm.MsgStatus = models.MsgStatusUploadedHaveNotEncoded
+			} else {
+				// TODO:pzhao, remove this and this should not be called.
+				message, err := oyster_utils.ChunkMessageToTrytesWithStopper(chunk.Data)
+				if err != nil {
+					panic(err.Error())
+				}
+				dm.Message = string(message)
+				dm.MsgStatus = models.MsgStatusUploadedNoNeedEncode
+			}
+
+			if oyster_utils.BrokerMode == oyster_utils.TestModeNoTreasure {
+				dm.Status = models.Unassigned
+			}
+			vErr, _ := dm.Validate(nil)
+			oyster_utils.LogIfValidationError("Unable to create data_maps for batch insertion.", vErr, nil)
+			if !vErr.HasAny() {
+				updatedDms = append(updatedDms, fmt.Sprintf("(%s)", dbOperation.GetUpdatedValue(dm)))
+			}
 		}
-		break
+	}
+
+	err = batchUpsertDataMaps(updatedDms, dbOperation.GetColumns())
+	// Save Message field into KVStore
+	if err == nil && services.IsKvStoreEnabled() {
+		services.BatchSet(&batchSetKvMap)
 	}
 }
 

--- a/jobs/process_paid_sessions.go
+++ b/jobs/process_paid_sessions.go
@@ -14,8 +14,21 @@ func ProcessPaidSessions(PrometheusWrapper services.PrometheusService) {
 	start := PrometheusWrapper.TimeNow()
 	defer PrometheusWrapper.HistogramSeconds(PrometheusWrapper.HistogramProcessPaidSessions, start)
 
+	EncryptKeysInTreasureIdxMaps()
 	BuryTreasureInDataMaps()
 	MarkBuriedMapsAsUnassigned()
+}
+
+func EncryptKeysInTreasureIdxMaps() {
+	needKeysEncrypted, err := models.GetSessionsThatNeedKeysEncrypted()
+	if err != nil {
+		fmt.Println(err)
+	}
+
+	for _, session := range needKeysEncrypted {
+
+		session.EncryptTreasureIdxMapKeys()
+	}
 }
 
 func BuryTreasureInDataMaps() error {

--- a/jobs/process_paid_sessions_test.go
+++ b/jobs/process_paid_sessions_test.go
@@ -159,13 +159,6 @@ func (suite *JobsSuite) Test_EncryptKeysInTreasureIdxMaps() {
 
 	fileBytesCount := uint64(500000)
 
-	// This map seems pointless but it makes the testing
-	// in the for loop later on a bit simpler
-	treasureIndexes := map[int]int{}
-	treasureIndexes[5] = 5
-	treasureIndexes[78] = 78
-	treasureIndexes[199] = 199
-
 	// create and start the upload session for the data maps that need treasure buried
 	uploadSession1 := models.UploadSession{
 		GenesisHash:    "abcdeff111111111111111111111111111111111111111111111",
@@ -178,9 +171,9 @@ func (suite *JobsSuite) Test_EncryptKeysInTreasureIdxMaps() {
 
 	uploadSession1.StartUploadSession()
 	mergedIndexes := []int{
-		treasureIndexes[5],
-		treasureIndexes[78],
-		treasureIndexes[199],
+		5,
+		78,
+		199,
 	}
 
 	privateKey1 := "0000000001"

--- a/jobs/process_paid_sessions_test.go
+++ b/jobs/process_paid_sessions_test.go
@@ -5,6 +5,7 @@ import (
 	"github.com/oysterprotocol/brokernode/jobs"
 	"github.com/oysterprotocol/brokernode/models"
 	"github.com/oysterprotocol/brokernode/services"
+	"github.com/oysterprotocol/brokernode/utils"
 )
 
 func (suite *JobsSuite) Test_ProcessPaidSessions() {
@@ -50,6 +51,7 @@ func (suite *JobsSuite) Test_ProcessPaidSessions() {
 	privateKeys := []string{"0000000001", "0000000002", "0000000003"}
 
 	uploadSession1.MakeTreasureIdxMap(mergedIndexes, privateKeys)
+	uploadSession1.EncryptTreasureIdxMapKeys()
 
 	// create and start the upload session for the data maps that already have buried treasure
 	uploadSession2 := models.UploadSession{
@@ -63,6 +65,11 @@ func (suite *JobsSuite) Test_ProcessPaidSessions() {
 	}
 
 	uploadSession2.StartUploadSession()
+	mergedIndexes = []int{treasureIndexes[5], treasureIndexes[78], treasureIndexes[199]}
+	privateKeys = []string{"0000000001", "0000000002", "0000000003"}
+
+	uploadSession2.MakeTreasureIdxMap(mergedIndexes, privateKeys)
+	uploadSession2.EncryptTreasureIdxMapKeys()
 
 	// verify that we have successfully created all the data maps
 	paidButUnburied := []models.DataMap{}
@@ -142,5 +149,90 @@ func (suite *JobsSuite) Test_ProcessPaidSessions() {
 	for _, entry := range treasureIndex {
 		_, ok := treasureIndexes[entry.Idx]
 		suite.True(ok)
+	}
+}
+
+func (suite *JobsSuite) Test_EncryptKeysInTreasureIdxMaps() {
+
+	oyster_utils.SetBrokerMode(oyster_utils.ProdMode)
+	defer oyster_utils.ResetBrokerMode()
+
+	fileBytesCount := uint64(500000)
+
+	// This map seems pointless but it makes the testing
+	// in the for loop later on a bit simpler
+	treasureIndexes := map[int]int{}
+	treasureIndexes[5] = 5
+	treasureIndexes[78] = 78
+	treasureIndexes[199] = 199
+
+	// create and start the upload session for the data maps that need treasure buried
+	uploadSession1 := models.UploadSession{
+		GenesisHash:    "abcdeff111111111111111111111111111111111111111111111",
+		NumChunks:      500,
+		FileSizeBytes:  fileBytesCount,
+		Type:           models.SessionTypeAlpha,
+		PaymentStatus:  models.PaymentStatusConfirmed,
+		TreasureStatus: models.TreasureGeneratingKeys,
+	}
+
+	uploadSession1.StartUploadSession()
+	mergedIndexes := []int{
+		treasureIndexes[5],
+		treasureIndexes[78],
+		treasureIndexes[199],
+	}
+
+	privateKey1 := "0000000001"
+	privateKey2 := "0000000002"
+	privateKey3 := "0000000003"
+
+	uploadSession1.MakeTreasureIdxMap(mergedIndexes, []string{
+		privateKey1,
+		privateKey2,
+		privateKey3,
+	})
+
+	treasureMap, err := uploadSession1.GetTreasureMap()
+	suite.Nil(err)
+
+	suite.Equal(3, len(treasureMap))
+
+	for _, entry := range treasureMap {
+		suite.True(entry.Key == privateKey1 ||
+			entry.Key == privateKey2 ||
+			entry.Key == privateKey3)
+	}
+
+	jobs.EncryptKeysInTreasureIdxMaps()
+
+	uploadSession := models.UploadSession{}
+	suite.DB.Where("genesis_hash = ?",
+		uploadSession1.GenesisHash).First(&uploadSession)
+
+	treasureMap2, err := uploadSession.GetTreasureMap()
+	suite.Nil(err)
+
+	suite.Equal(3, len(treasureMap2))
+
+	for _, entry := range treasureMap2 {
+		suite.True(entry.Key != privateKey1 &&
+			entry.Key != privateKey2 &&
+			entry.Key != privateKey3)
+	}
+
+	for _, entry := range treasureMap2 {
+		dm := models.DataMap{}
+		err := suite.DB.Where("genesis_hash = ? && chunk_idx = ?",
+			uploadSession1.GenesisHash,
+			entry.Idx).First(&dm)
+		suite.Nil(err)
+
+		decryptedKey, err := dm.DecryptEthKey(entry.Key)
+		suite.Nil(err)
+
+		suite.True(decryptedKey == privateKey1 ||
+			decryptedKey == privateKey2 ||
+			decryptedKey == privateKey3)
 	}
 }

--- a/models/completed_data_maps.go
+++ b/models/completed_data_maps.go
@@ -2,7 +2,7 @@ package models
 
 import (
 	"encoding/json"
-	"fmt"
+	"github.com/oysterprotocol/brokernode/utils"
 	"time"
 
 	"github.com/gobuffalo/pop"
@@ -76,5 +76,5 @@ func (d *CompletedDataMap) BeforeCreate(tx *pop.Connection) error {
 }
 
 func (d *CompletedDataMap) generateMsgId() string {
-	return fmt.Sprintf("completeDataMap_%v__%d", d.GenesisHash, d.ChunkIdx)
+	return oyster_utils.GenerateMsgID("completeDataMap_", d.GenesisHash, d.ChunkIdx)
 }

--- a/models/data_maps.go
+++ b/models/data_maps.go
@@ -189,7 +189,7 @@ func (d *DataMap) DecryptEthKey(encryptedKey string) (string, error) {
 }
 
 func (d *DataMap) generateMsgId() string {
-	return fmt.Sprintf("%v__%d", d.GenesisHash, d.ChunkIdx)
+	return oyster_utils.GenerateMsgID("", d.GenesisHash, d.ChunkIdx)
 }
 
 // Computes a particular sectorIdx addresses in term of DataMaps. Limit by maxNumbOfHashes.

--- a/models/upload_sessions.go
+++ b/models/upload_sessions.go
@@ -68,6 +68,8 @@ const (
 	TreasureInDataMapComplete
 )
 
+const MaxTimesToCheckForAllChunks = 1000
+
 var StoragePeg = decimal.NewFromFloat(float64(64)) // GB per year per PRL; TODO: query smart contract for real storage peg
 
 // String is not required by pop and may be deleted
@@ -190,6 +192,10 @@ func (u *UploadSession) StartUploadSession() (vErr *validate.Errors, err error) 
 	go func() {
 		vErr, err = BuildDataMaps(u.GenesisHash, u.NumChunks)
 	}()
+	// TODO:  Remove this.  This is just to help make these changes in
+	// fewer PRs.  We may need to use WaitForAllChunks in some of our tests.
+	_, err = u.WaitForAllChunks()
+	oyster_utils.LogIfError(err, nil)
 	return
 }
 
@@ -258,34 +264,60 @@ func (u *UploadSession) SetTreasureMap(treasureIndexMap []TreasureMap) error {
 	return err
 }
 
+// EncryptTreasureIdxMapKeys encrypts the keys of the treasureIdxMap
+func (u *UploadSession) EncryptTreasureIdxMapKeys() error {
+
+	treasureMap, err := u.GetTreasureMap()
+	if err != nil {
+		oyster_utils.LogIfError(err, nil)
+		return err
+	}
+
+	for i := range treasureMap {
+		treasureChunks, err := GetDataMapByGenesisHashAndChunkIdx(u.GenesisHash, treasureMap[i].Idx)
+		if err != nil {
+			fmt.Println(err)
+			return err
+		}
+		if len(treasureChunks) == 0 || len(treasureChunks) > 1 {
+			err = errors.New("did not find a chunk that matched genesis_hash and chunk_idx in " +
+				"EncryptTreasureIdxMapKeys, or found duplicate chunks")
+			oyster_utils.LogIfError(err, nil)
+			return err
+		}
+
+		encryptedKey, err := treasureChunks[0].EncryptEthKey(treasureMap[i].Key)
+		if err != nil {
+			fmt.Println(err)
+			return err
+		}
+		treasureMap[i].Key = encryptedKey
+	}
+
+	treasureString, err := json.Marshal(treasureMap)
+	if err != nil {
+		oyster_utils.LogIfError(err, nil)
+	}
+
+	u.TreasureIdxMap = nulls.String{string(treasureString), true}
+	u.TreasureStatus = TreasureInDataMapPending
+
+	DB.ValidateAndSave(u)
+	return nil
+
+}
+
 // Sets the TreasureIdxMap with Sector, Idx, and Key
 func (u *UploadSession) MakeTreasureIdxMap(mergedIndexes []int, privateKeys []string) {
 
 	treasureIndexArray := make([]TreasureMap, 0)
 
 	for i, mergedIndex := range mergedIndexes {
-		treasureChunks, err := GetDataMapByGenesisHashAndChunkIdx(u.GenesisHash, mergedIndex)
-		if err != nil {
-			fmt.Println(err)
-			return
-		}
-		if len(treasureChunks) == 0 || len(treasureChunks) > 1 {
-			err = errors.New("did not find a chunk that matched genesis_hash and chunk_idx in MakeTreasureIdxMap, or " +
-				"found duplicate chunks")
-			oyster_utils.LogIfError(err, nil)
-			return
-		}
-
-		encryptedKey, err := treasureChunks[0].EncryptEthKey(privateKeys[i])
-		if err != nil {
-			fmt.Println(err)
-			return
-		}
 
 		treasureIndexArray = append(treasureIndexArray, TreasureMap{
 			Sector: i,
 			Idx:    mergedIndex,
-			Key:    encryptedKey,
+			Key:    privateKeys[i],
 		})
 	}
 
@@ -295,7 +327,6 @@ func (u *UploadSession) MakeTreasureIdxMap(mergedIndexes []int, privateKeys []st
 	}
 
 	u.TreasureIdxMap = nulls.String{string(treasureString), true}
-	u.TreasureStatus = TreasureInDataMapPending
 
 	DB.ValidateAndSave(u)
 }
@@ -403,6 +434,26 @@ func (u *UploadSession) DecryptSessionEthKey() string {
 
 }
 
+func (u *UploadSession) WaitForAllChunks() (bool, error) {
+	timesChecked := 0
+	for {
+		count, err := DB.Where("genesis_hash = ?", u.GenesisHash).Count(&DataMap{})
+		timesChecked++
+		if err != nil {
+			return false, err
+		}
+		if timesChecked >= MaxTimesToCheckForAllChunks {
+			return false, errors.New("checked for the chunks too many times")
+		}
+		if count >= u.NumChunks {
+			break
+		} else if count <= u.NumChunks {
+			time.Sleep(500 * time.Millisecond)
+		}
+	}
+	return true, nil
+}
+
 func GetSessionsByAge() ([]UploadSession, error) {
 	sessionsByAge := []UploadSession{}
 
@@ -415,6 +466,18 @@ func GetSessionsByAge() ([]UploadSession, error) {
 	}
 
 	return sessionsByAge, nil
+}
+
+// GetSessionsThatNeedKeysEncrypted checks for sessions which the user has paid their PRL but in which
+// we have not yet encrypted the keys
+func GetSessionsThatNeedKeysEncrypted() ([]UploadSession, error) {
+	needKeysEncrypted := []UploadSession{}
+
+	err := DB.Where("payment_status = ? AND treasure_status = ?",
+		PaymentStatusConfirmed, TreasureGeneratingKeys).All(&needKeysEncrypted)
+	oyster_utils.LogIfError(err, nil)
+
+	return needKeysEncrypted, err
 }
 
 // GetSessionsThatNeedTreasure checks for sessions which the user has paid their PRL but in which

--- a/models/upload_sessions.go
+++ b/models/upload_sessions.go
@@ -187,7 +187,9 @@ func (u *UploadSession) StartUploadSession() (vErr *validate.Errors, err error) 
 		DB.ValidateAndUpdate(u)
 	}
 
-	vErr, err = BuildDataMaps(u.GenesisHash, u.NumChunks)
+	go func() {
+		vErr, err = BuildDataMaps(u.GenesisHash, u.NumChunks)
+	}()
 	return
 }
 

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -373,3 +373,7 @@ func IntMax(x, y int) int {
 	}
 	return y
 }
+
+func GenerateMsgID(startingString string, genesisHash string, chunkIdx int) string {
+	return fmt.Sprintf("%v%v__%d", startingString, genesisHash, chunkIdx)
+}


### PR DESCRIPTION
Changes so that MakeTreasureIdxMap can be async.  

How it was handled before:
-wait for all data map entries to be built
-make the treasure map and encrypt the eth keys all in one step in actions/upload_sessions

How it is handled now:
-go ahead and create the treasure idx map regardless of whether the chunks are ready or not.  Keys will not yet be encrypted
-in process_paid_sessions, check for sessions whose treasure keys need encrypting.  Encrypt them if the treasure chunks exist.  Otherwise, wait until the next time the task is called.  