### PR TITLE
Hot fixes

### DIFF
--- a/jobs/job_runner.go
+++ b/jobs/job_runner.go
@@ -67,7 +67,7 @@ func doWork(oysterWorker *worker.Simple) {
 		worker.Args{Duration: time.Duration(services.GetProcessingFrequency()) * time.Second})
 
 	oysterWorkerPerformIn(purgeCompletedSessionsHandler,
-		worker.Args{Duration: 10 * time.Minute})
+		worker.Args{Duration: 1 * time.Minute})
 
 	oysterWorkerPerformIn(verifyDataMapsHandler,
 		worker.Args{Duration: 30 * time.Second})

--- a/migrations/20180320145525_create_completed_data_maps.up.sql
+++ b/migrations/20180320145525_create_completed_data_maps.up.sql
@@ -1,5 +1,5 @@
 CREATE TABLE IF NOT EXISTS `completed_data_maps` (
-  `id`              int(11)      NOT NULL AUTO_INCREMENT,
+  `id`              char(36)     NOT NULL,
   `genesis_hash`    varchar(255) NOT NULL,
   `chunk_idx`       int(11)      NOT NULL,
   `hash`            varchar(255) NOT NULL,
@@ -17,6 +17,4 @@ CREATE TABLE IF NOT EXISTS `completed_data_maps` (
   KEY `completed_data_maps_genesis_hash_chunk_idx_idx` (`genesis_hash`, `chunk_idx`)
 )
   ENGINE = InnoDB
-  AUTO_INCREMENT = 224645205
   DEFAULT CHARSET = latin1;
-

--- a/models/completed_data_maps.go
+++ b/models/completed_data_maps.go
@@ -2,6 +2,7 @@ package models
 
 import (
 	"encoding/json"
+	"github.com/gobuffalo/uuid"
 	"github.com/oysterprotocol/brokernode/utils"
 	"time"
 
@@ -11,7 +12,7 @@ import (
 )
 
 type CompletedDataMap struct {
-	ID             int       `json:"id" db:"id"`
+	ID             uuid.UUID `json:"id" db:"id"`
 	CreatedAt      time.Time `json:"createdAt" db:"created_at"`
 	UpdatedAt      time.Time `json:"updatedAt" db:"updated_at"`
 	Status         int       `json:"status" db:"status"`

--- a/services/iota_wrappers.go
+++ b/services/iota_wrappers.go
@@ -149,7 +149,7 @@ func init() {
 		go PowWorker(Channel[channel.ChannelID].Channel, channel.ChannelID, err)
 	}
 
-	PoWFrequency.Frequency = 5
+	PoWFrequency.Frequency = 2
 }
 
 func PowWorker(jobQueue <-chan PowJob, channelID string, err error) {


### PR DESCRIPTION
-purgeCompletedSessions needs to run a lot more often, otherwise the data_maps table grows wildly out of control
-The completed_data_maps table on prod now has a UUID primary key like all the others rather than auto-incrementing int.  Have updated the original migration file instead of making a new one, since it reflects the current status of the prod table and it doesn't matter for the dev tables since we tear those down everytime anyway.  
-lower the default powFrequency.  This will very quickly get calibrated by how long the PoW actually takes on the broker, but might as well start it off a couple seconds sooner.