### PR TITLE
Enable KV Store to Create New DB with Each New Upload Session

### DIFF
--- a/actions/upload_sessions.go
+++ b/actions/upload_sessions.go
@@ -417,7 +417,7 @@ func convertToBadgerKeyedMapForChunks(chunks []chunkReq, genesisHash string, tre
 			chunkIdx = oyster_utils.TransformIndexWithBuriedIndexes(chunk.Idx, treasureIdxMap)
 		}
 
-		key := oyster_utils.GenerateMsgID("", genesisHash, chunkIdx)
+		key := oyster_utils.GenerateBadgerKey("", genesisHash, chunkIdx)
 		chunksMap[key] = chunk
 	}
 	return chunksMap

--- a/jobs/purge_completed_sessions.go
+++ b/jobs/purge_completed_sessions.go
@@ -170,7 +170,7 @@ func moveToComplete(dataMaps []models.DataMap) error {
 			Hash:        dataMap.Hash,
 			Address:     dataMap.Address,
 			MsgStatus:   dataMap.MsgStatus,
-			MsgID:       oyster_utils.GenerateMsgID(models.CompletedDataMapsMsgIDPrefix, dataMap.GenesisHash, dataMap.ChunkIdx),
+			MsgID:       oyster_utils.GenerateBadgerKey(models.CompletedDataMapsMsgIDPrefix, dataMap.GenesisHash, dataMap.ChunkIdx),
 		}
 		if !services.IsKvStoreEnabled() {
 			completedDataMap.Message = services.GetMessageFromDataMap(dataMap)

--- a/models/completed_data_maps.go
+++ b/models/completed_data_maps.go
@@ -86,5 +86,5 @@ func (d *CompletedDataMap) BeforeCreate(tx *pop.Connection) error {
 }
 
 func (d *CompletedDataMap) generateMsgId() string {
-	return oyster_utils.GenerateMsgID(CompletedDataMapsMsgIDPrefix, d.GenesisHash, d.ChunkIdx)
+	return oyster_utils.GenerateBadgerKey(CompletedDataMapsMsgIDPrefix, d.GenesisHash, d.ChunkIdx)
 }

--- a/models/data_maps.go
+++ b/models/data_maps.go
@@ -193,7 +193,7 @@ func (d *DataMap) DecryptEthKey(encryptedKey string) (string, error) {
 }
 
 func (d *DataMap) generateMsgId() string {
-	return oyster_utils.GenerateMsgID("", d.GenesisHash, d.ChunkIdx)
+	return oyster_utils.GenerateBadgerKey("", d.GenesisHash, d.ChunkIdx)
 }
 
 // Computes a particular sectorIdx addresses in term of DataMaps. Limit by maxNumbOfHashes.

--- a/services/kv_store.go
+++ b/services/kv_store.go
@@ -13,17 +13,30 @@ import (
 
 // const badgerDir = "/tmp/badger" // TODO: CHANGE THIS.
 const badgerDir = "/var/lib/badger/prod"
+const CompletedDir = "completed"
+const InProgressDir = "current"
+const HashDir = "hash"
+const MessageDir = "message"
 
 // Singleton DB
 var badgerDB *badger.DB
 var dbNoInitError error
 var isKvStoreEnable bool
 var badgerDirTest string
+var DBMap KVDBMap
 
+type KVDBMap map[string]*badger.DB
 type KVPairs map[string]string
 type KVKeys []string
 
+type ChunkData struct {
+	Address string
+	Hash    string
+	Message string
+}
+
 func init() {
+	DBMap = make(KVDBMap)
 	dbNoInitError = errors.New("badgerDB not initialized, Call InitKvStore() first")
 
 	badgerDirTest, _ = ioutil.TempDir("", "badgerForUnitTest")
@@ -38,6 +51,30 @@ func init() {
 			panic(err.Error())
 		}
 	}
+}
+
+/*InitUniqueKvStore creates a new K:V store associated with a particular upload*/
+func InitUniqueKvStore(dirName string) error {
+	if DBMap[dirName] != nil {
+		return nil
+	}
+
+	opts := badger.DefaultOptions
+
+	if os.Getenv("GO_ENV") == "test" {
+		opts.Dir = badgerDirTest + "/" + dirName
+		opts.ValueDir = badgerDirTest + "/" + dirName
+	} else {
+		opts.Dir = badgerDir + "/" + dirName
+		opts.ValueDir = badgerDir + "/" + dirName
+	}
+
+	db, err := badger.Open(opts)
+	oyster_utils.LogIfError(err, nil)
+	if err == nil {
+		DBMap[dirName] = db
+	}
+	return err
 }
 
 /*InitKvStore returns db so that caller can call CloseKvStore to close it when it is done.*/
@@ -62,6 +99,17 @@ func InitKvStore() (err error) {
 	return err
 }
 
+/*CloseUniqueKvStore closes the K:V store associated with a particular upload.*/
+func CloseUniqueKvStore(dirName string) error {
+	if DBMap[dirName] == nil {
+		return nil
+	}
+	err := DBMap[dirName].Close()
+	oyster_utils.LogIfError(err, nil)
+	DBMap[dirName] = nil
+	return err
+}
+
 /*CloseKvStore closes the db.*/
 func CloseKvStore() error {
 	if badgerDB == nil {
@@ -71,6 +119,45 @@ func CloseKvStore() error {
 	oyster_utils.LogIfError(err, nil)
 	badgerDB = nil
 	return err
+}
+
+/*RemoveAllUniqueKvStoreData removes all the data associated with a particular K:V store.*/
+func RemoveAllUniqueKvStoreData(dirName string) error {
+	if err := CloseUniqueKvStore(dirName); err != nil {
+		return err
+	}
+
+	var dir string
+	if os.Getenv("GO_ENV") == "test" {
+		dir = badgerDirTest + "/" + dirName
+	} else {
+		dir = badgerDir + "/" + dirName
+	}
+
+	err := os.RemoveAll(dir)
+	oyster_utils.LogIfError(err, map[string]interface{}{"badgerDir": dir})
+	return err
+}
+
+/*RemoveAllKvStoreDataFromAllKvStores removes all the data associated with all K:V stores.*/
+func RemoveAllKvStoreDataFromAllKvStores() []error {
+	var errArray []error
+	for dirName := range DBMap {
+		if err := CloseUniqueKvStore(dirName); err != nil {
+			errArray = append(errArray, err)
+			continue
+		}
+
+		var dir string
+		if os.Getenv("GO_ENV") == "test" {
+			dir = badgerDirTest + "/" + dirName
+		} else {
+			dir = badgerDir + "/" + dirName
+		}
+		err := os.RemoveAll(dir)
+		oyster_utils.LogIfError(err, map[string]interface{}{"badgerDir": dir})
+	}
+	return errArray
 }
 
 /*RemoveAllKvStoreData removes all the data. Caller should call InitKvStore() again to create a new one.*/
@@ -88,6 +175,23 @@ func RemoveAllKvStoreData() error {
 	err := os.RemoveAll(dir)
 	oyster_utils.LogIfError(err, map[string]interface{}{"badgerDir": dir})
 	return err
+}
+
+/*GetUniqueBadgerDb returns a database associated with an upload.  If not initialized this will return nil. */
+func GetUniqueBadgerDb(dirName string) *badger.DB {
+	return DBMap[dirName]
+}
+
+/*GetOrInitUniqueBadgerDB returns a database associated with an upload. */
+func GetOrInitUniqueBadgerDB(dirName string) *badger.DB {
+	db := GetUniqueBadgerDb(dirName)
+	if db != nil {
+		return db
+	}
+
+	err := InitUniqueKvStore(dirName)
+	oyster_utils.LogIfError(err, nil)
+	return GetUniqueBadgerDb(dirName)
 }
 
 /*GetBadgerDb returns the underlying the database. If not call InitKvStore(), it will return nil*/
@@ -116,6 +220,88 @@ func GetMessageFromDataMap(dataMap models.DataMap) string {
 	}
 
 	return value
+}
+
+/*GetChunkData returns the message, hash, and address for a chunk.*/
+func GetChunkData(prefix string, genesisHash string, chunkIdx int) ChunkData {
+
+	key := oyster_utils.GenerateBadgerKey(prefix, genesisHash, chunkIdx)
+
+	hashDBDir := prefix + "/" + HashDir + "/" + genesisHash
+	messageDBDir := prefix + "/" + MessageDir + "/" + genesisHash
+
+	GetOrInitUniqueBadgerDB(hashDBDir)
+	GetOrInitUniqueBadgerDB(messageDBDir)
+
+	hash := ""
+	message := ""
+
+	hashValues, _ := BatchGetFromUniqueDB(hashDBDir,
+		&KVKeys{key})
+	if v, hasKey := (*hashValues)[key]; hasKey {
+		hash = v
+	}
+
+	messageValues, _ := BatchGetFromUniqueDB(messageDBDir,
+		&KVKeys{key})
+	if v, hasKey := (*messageValues)[key]; hasKey {
+		message = v
+	}
+
+	trytes, _ := oyster_utils.ChunkMessageToTrytesWithStopper(message)
+	message = string(trytes)
+
+	address := oyster_utils.Sha256ToAddress(hash)
+
+	return ChunkData{
+		Address: address,
+		Message: message,
+		Hash:    hash,
+	}
+}
+
+/*BatchGetFromUniqueDB returns KVPairs for a set of keys from a specific DB.
+It won't treat Key missing as error.*/
+func BatchGetFromUniqueDB(dirName string, ks *KVKeys) (kvs *KVPairs, err error) {
+	kvs = &KVPairs{}
+	if DBMap[dirName] == nil {
+		DBMap[dirName] = GetOrInitUniqueBadgerDB(dirName)
+	}
+
+	err = DBMap[dirName].View(func(txn *badger.Txn) error {
+		for _, k := range *ks {
+			// Skip any empty keys.
+			if k == "" {
+				continue
+			}
+
+			item, err := txn.Get([]byte(k))
+			if err == badger.ErrKeyNotFound {
+				continue
+			}
+			if err != nil {
+				return err
+			}
+
+			val := ""
+			if item != nil {
+				valBytes, err := item.Value()
+				if err != nil {
+					return err
+				}
+
+				val = string(valBytes)
+			}
+
+			// Mutate KV map
+			(*kvs)[k] = val
+		}
+
+		return nil
+	})
+	oyster_utils.LogIfError(err, map[string]interface{}{"batchSize": len(*ks)})
+
+	return
 }
 
 /*BatchGet returns KVPairs for a set of keys. It won't treat Key missing as error.*/
@@ -161,6 +347,50 @@ func BatchGet(ks *KVKeys) (kvs *KVPairs, err error) {
 	return
 }
 
+/*BatchSetToUniqueDB updates a set of KVPairs in a unique database.
+Return error if any fails.*/
+func BatchSetToUniqueDB(dirName string, kvs *KVPairs, ttl time.Duration) error {
+	if DBMap[dirName] == nil {
+		DBMap[dirName] = GetOrInitUniqueBadgerDB(dirName)
+	}
+
+	var err error
+	txn := DBMap[dirName].NewTransaction(true)
+	for k, v := range *kvs {
+		if k == "" {
+			err = errors.New("BatchSetToUniqueDB does not accept key as empty string")
+			break
+		}
+
+		e := txn.SetWithTTL([]byte(k), []byte(v), ttl)
+		if e == nil {
+			continue
+		}
+
+		if e == badger.ErrTxnTooBig {
+			e = nil
+			if commitErr := txn.Commit(nil); commitErr != nil {
+				e = commitErr
+			} else {
+				txn = DBMap[dirName].NewTransaction(true)
+				e = txn.SetWithTTL([]byte(k), []byte(v), ttl)
+			}
+		}
+
+		if e != nil {
+			err = e
+			break
+		}
+	}
+
+	defer txn.Discard()
+	if err == nil {
+		err = txn.Commit(nil)
+	}
+	oyster_utils.LogIfError(err, map[string]interface{}{"batchSize": len(*kvs)})
+	return err
+}
+
 /*BatchSet updates a set of KVPairs. Return error if any fails.*/
 func BatchSet(kvs *KVPairs, ttl time.Duration) error {
 	if badgerDB == nil {
@@ -204,6 +434,46 @@ func BatchSet(kvs *KVPairs, ttl time.Duration) error {
 	return err
 }
 
+/*BatchDeleteFromUniqueDB deletes a set of KVKeys from a specific DB.
+Return error if any fails.*/
+func BatchDeleteFromUniqueDB(dirName string, ks *KVKeys) error {
+	if DBMap[dirName] == nil {
+		DBMap[dirName] = GetOrInitUniqueBadgerDB(dirName)
+	}
+
+	var err error
+	txn := DBMap[dirName].NewTransaction(true)
+	for _, key := range *ks {
+		e := txn.Delete([]byte(key))
+		if e == nil {
+			continue
+		}
+
+		if e == badger.ErrTxnTooBig {
+			e = nil
+			if commitErr := txn.Commit(nil); commitErr != nil {
+				e = commitErr
+			} else {
+				txn = DBMap[dirName].NewTransaction(true)
+				e = txn.Delete([]byte(key))
+			}
+		}
+
+		if e != nil {
+			err = e
+			break
+		}
+	}
+
+	defer txn.Discard()
+	if err == nil {
+		err = txn.Commit(nil)
+	}
+
+	oyster_utils.LogIfError(err, map[string]interface{}{"batchSize": len(*ks)})
+	return err
+}
+
 /*BatchDelete deletes a set of KVKeys, Return error if any fails.*/
 func BatchDelete(ks *KVKeys) error {
 	if badgerDB == nil {
@@ -241,6 +511,32 @@ func BatchDelete(ks *KVKeys) error {
 
 	oyster_utils.LogIfError(err, map[string]interface{}{"batchSize": len(*ks)})
 	return err
+}
+
+/*DeleteDataFromUniqueDB deletes the data from a specific DB for all
+chunks within a certain range.  Note that endingIdx is inclusive */
+func DeleteDataFromUniqueDB(dirName string, prefix string, genesisHash string, startingIdx int,
+	endingIdx int) {
+
+	var keys KVKeys
+	step := 0
+	stop := 0
+
+	if startingIdx < endingIdx {
+		step = 1
+		stop = endingIdx + step
+	} else if startingIdx > endingIdx {
+		step = -1
+		stop = endingIdx + step
+	} else {
+		keys = append(keys, oyster_utils.GenerateBadgerKey(prefix, genesisHash, startingIdx))
+	}
+
+	for i := startingIdx; i != stop; i = i + step {
+		keys = append(keys, oyster_utils.GenerateBadgerKey(prefix, genesisHash, i))
+	}
+
+	BatchDeleteFromUniqueDB(dirName, &keys)
 }
 
 /*DeleteMsgDatas deletes the data referred by dataMaps. */

--- a/services/kv_store.go
+++ b/services/kv_store.go
@@ -211,7 +211,7 @@ func RemoveAllUniqueKvStoreData(dbName string) error {
 	if os.Getenv("GO_ENV") == "test" {
 		dir = badgerDirTest + directoryPath
 	} else {
-		dir = badgerDir + "/" + directoryPath
+		dir = badgerDir + string(os.PathSeparator) + directoryPath
 	}
 
 	err := os.RemoveAll(dir)
@@ -224,6 +224,7 @@ func RemoveAllUniqueKvStoreData(dbName string) error {
 func RemoveAllKvStoreDataFromAllKvStores() []error {
 	var errArray []error
 	for dbName := range dbMap {
+		directoryPath := dbMap[dbName].DirectoryPath
 		if err := CloseUniqueKvStore(dbName); err != nil {
 			errArray = append(errArray, err)
 			continue
@@ -231,9 +232,9 @@ func RemoveAllKvStoreDataFromAllKvStores() []error {
 
 		var dir string
 		if os.Getenv("GO_ENV") == "test" {
-			dir = badgerDirTest + "/" + dbMap[dbName].DirectoryPath
+			dir = badgerDirTest + directoryPath
 		} else {
-			dir = badgerDir + "/" + dbMap[dbName].DirectoryPath
+			dir = badgerDir + string(os.PathSeparator) + directoryPath
 		}
 		err := os.RemoveAll(dir)
 		oyster_utils.LogIfError(err, map[string]interface{}{"badgerDir": dir})

--- a/services/kv_store_test.go
+++ b/services/kv_store_test.go
@@ -2,6 +2,7 @@ package services_test
 
 import (
 	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/oysterprotocol/brokernode/models"
@@ -11,6 +12,8 @@ import (
 
 // a very big number that will lead to ErrTxnTooBig for write.
 const guessedMaxBatchSize = 200000
+
+var testDBID = []string{"prefix", "genHash", "data"}
 
 func Test_KVStore_Init(t *testing.T) {
 	err := services.InitKvStore()
@@ -145,4 +148,303 @@ func getKeys(count int) *services.KVKeys {
 		keys = append(keys, strconv.Itoa(i))
 	}
 	return &keys
+}
+
+func Test_KVStore_InitUniqueKvStore(t *testing.T) {
+	err := services.InitUniqueKvStore(testDBID)
+	dbName := services.GetBadgerDBName(testDBID)
+
+	oyster_utils.AssertNoError(err, t, "Could not create Badger DB")
+	defer services.CloseUniqueKvStore(dbName)
+}
+
+func Test_KVStore_MassBatchSetToUniqueDB(t *testing.T) {
+	services.InitUniqueKvStore(testDBID)
+	dbName := services.GetBadgerDBName(testDBID)
+	defer services.CloseUniqueKvStore(dbName)
+
+	err := services.BatchSetToUniqueDB(testDBID,
+		getKvPairs(guessedMaxBatchSize), models.TestValueTimeToLive)
+	oyster_utils.AssertNoError(err, t, "")
+
+	kvs, _ := services.BatchGetFromUniqueDB(testDBID,
+		&services.KVKeys{strconv.Itoa(guessedMaxBatchSize - 1)})
+	oyster_utils.AssertTrue(len(*kvs) == 1, t, "Expect only an item")
+}
+
+func Test_KVStore_BatchGetFromUniqueDB(t *testing.T) {
+	services.InitUniqueKvStore(testDBID)
+	dbName := services.GetBadgerDBName(testDBID)
+	defer services.CloseUniqueKvStore(dbName)
+
+	services.BatchSetToUniqueDB(testDBID, &services.KVPairs{"key": "oyster"},
+		models.TestValueTimeToLive)
+
+	kvs, err := services.BatchGetFromUniqueDB(testDBID, &services.KVKeys{"key"})
+	oyster_utils.AssertNoError(err, t, "Could not get key")
+
+	oyster_utils.AssertTrue(len(*kvs) == 1, t, "")
+	oyster_utils.AssertStringEqual((*kvs)["key"], "oyster", t)
+}
+
+func Test_KVStore_BatchGetFromUniqueDB_WithMissingKey(t *testing.T) {
+	services.InitUniqueKvStore(testDBID)
+	dbName := services.GetBadgerDBName(testDBID)
+	defer services.CloseUniqueKvStore(dbName)
+
+	services.BatchSetToUniqueDB(testDBID, &services.KVPairs{"key": "oyster"},
+		models.TestValueTimeToLive)
+
+	kvs, err := services.BatchGetFromUniqueDB(testDBID,
+		&services.KVKeys{"key", "unknownKey"})
+	oyster_utils.AssertNoError(err, t, "Could not get key")
+
+	oyster_utils.AssertTrue(len(*kvs) == 1, t, "")
+	oyster_utils.AssertStringEqual((*kvs)["key"], "oyster", t)
+}
+
+func Test_KVStore_MassBatchGetFromUniqueDB(t *testing.T) {
+	services.InitUniqueKvStore(testDBID)
+	dbName := services.GetBadgerDBName(testDBID)
+	defer services.CloseUniqueKvStore(dbName)
+
+	err := services.BatchSetToUniqueDB(testDBID,
+		getKvPairs(guessedMaxBatchSize), models.TestValueTimeToLive)
+	oyster_utils.AssertNoError(err, t, "")
+
+	kvs, _ := services.BatchGetFromUniqueDB(testDBID, getKeys(guessedMaxBatchSize))
+	oyster_utils.AssertTrue(len(*kvs) == guessedMaxBatchSize, t, "")
+}
+
+func Test_KVStore_BatchDeleteFromUniqueDB(t *testing.T) {
+	services.InitUniqueKvStore(testDBID)
+	dbName := services.GetBadgerDBName(testDBID)
+	defer services.CloseUniqueKvStore(dbName)
+
+	services.BatchSetToUniqueDB(testDBID,
+		&services.KVPairs{"key1": "oyster1", "key2": "oyster2"}, models.TestValueTimeToLive)
+
+	err := services.BatchDeleteFromUniqueDB(testDBID,
+		&services.KVKeys{"key1"})
+	oyster_utils.AssertNoError(err, t, "Could not delete key")
+
+	kvs, err := services.BatchGetFromUniqueDB(testDBID,
+		&services.KVKeys{"key1"})
+	oyster_utils.AssertNoError(err, t, "Could complete get key")
+	oyster_utils.AssertTrue(len(*kvs) == 0, t, "")
+}
+
+func Test_KVStore_Mass_BatchDeleteFromUniqueDB(t *testing.T) {
+	services.InitUniqueKvStore(testDBID)
+	dbName := services.GetBadgerDBName(testDBID)
+	defer services.CloseUniqueKvStore(dbName)
+
+	err := services.BatchSetToUniqueDB(testDBID,
+		getKvPairs(guessedMaxBatchSize), models.TestValueTimeToLive)
+	oyster_utils.AssertNoError(err, t, "")
+
+	err = services.BatchDeleteFromUniqueDB(testDBID,
+		getKeys(guessedMaxBatchSize))
+	oyster_utils.AssertNoError(err, t, "")
+}
+
+func Test_KVStore_RemoveAllUniqueKvStoreData(t *testing.T) {
+	services.InitUniqueKvStore(testDBID)
+	dbName := services.GetBadgerDBName(testDBID)
+	defer services.CloseUniqueKvStore(dbName)
+
+	services.BatchSetToUniqueDB(testDBID, getKvPairs(2), models.TestValueTimeToLive)
+	err := services.RemoveAllUniqueKvStoreData(dbName)
+	oyster_utils.AssertNoError(err, t, "")
+
+	services.InitUniqueKvStore(testDBID)
+	kvs, _ := services.BatchGetFromUniqueDB(testDBID, getKeys(2))
+
+	oyster_utils.AssertTrue(len(*kvs) == 0, t, "")
+}
+
+func Test_KVStore_RemoveAllKvStoreDataFromAllKvStores(t *testing.T) {
+
+	dbID1 := []string{"prefix", "genhash1", services.MessageDir}
+	dbID2 := []string{"prefix", "genhash2", services.MessageDir}
+
+	services.InitUniqueKvStore(dbID1)
+	dbName1 := services.GetBadgerDBName(dbID1)
+	defer services.CloseUniqueKvStore(dbName1)
+
+	services.InitUniqueKvStore(dbID2)
+	dbName2 := services.GetBadgerDBName(dbID2)
+	defer services.CloseUniqueKvStore(dbName2)
+
+	services.BatchSetToUniqueDB(dbID1, getKvPairs(2), models.TestValueTimeToLive)
+	services.BatchSetToUniqueDB(dbID2, getKvPairs(2), models.TestValueTimeToLive)
+
+	services.RemoveAllKvStoreDataFromAllKvStores()
+
+	services.InitUniqueKvStore(dbID1)
+	services.InitUniqueKvStore(dbID2)
+
+	kvs1, _ := services.BatchGetFromUniqueDB(dbID1, getKeys(2))
+	kvs2, _ := services.BatchGetFromUniqueDB(dbID2, getKeys(2))
+
+	oyster_utils.AssertTrue(len(*kvs1) == 0, t, "")
+	oyster_utils.AssertTrue(len(*kvs2) == 0, t, "")
+}
+
+func Test_KVStore_GetChunkData(t *testing.T) {
+
+	prefix := "somePrefix"
+	genesisHash := "someGenHash"
+
+	messageDBID := []string{prefix, genesisHash, services.MessageDir}
+	messageDBName := services.GetBadgerDBName(messageDBID)
+
+	hashDBID := []string{prefix, genesisHash, services.HashDir}
+	hashDBName := services.GetBadgerDBName(hashDBID)
+
+	hash := "abcdeff"
+	message := "testMessage"
+	testAddress := "PHYDCDNGNEKFPAHEO9VHR9UAKFLDLGICICIIJCNDLGMGIASAUCCHBCIDIDVCWC9EIGEFZAQDH9AIAIUFN"
+
+	services.InitUniqueKvStore(messageDBID)
+	services.InitUniqueKvStore(hashDBID)
+
+	defer services.CloseUniqueKvStore(messageDBName)
+	defer services.CloseUniqueKvStore(hashDBName)
+
+	services.BatchSetToUniqueDB(messageDBID,
+		&services.KVPairs{
+			genesisHash + "_1": message + "1",
+			genesisHash + "_2": message + "2",
+			genesisHash + "_3": message + "3",
+			genesisHash + "_4": message + "4",
+			genesisHash + "_5": message + "5",
+			genesisHash + "_6": message + "6"},
+		models.TestValueTimeToLive)
+
+	services.BatchSetToUniqueDB(hashDBID,
+		&services.KVPairs{
+			genesisHash + "_1": hash + "1",
+			genesisHash + "_2": hash + "2",
+			genesisHash + "_3": hash + "3",
+			genesisHash + "_4": hash + "4",
+			genesisHash + "_5": hash + "5",
+			genesisHash + "_6": hash + "6"},
+		models.TestValueTimeToLive)
+
+	chunkData := services.GetChunkData(prefix, genesisHash, 3)
+
+	trytes, _ := oyster_utils.ChunkMessageToTrytesWithStopper(message + "3")
+
+	oyster_utils.AssertContainString(chunkData.Hash, hash, t)
+	oyster_utils.AssertContainString(chunkData.Message, string(trytes), t)
+	oyster_utils.AssertStringEqual(chunkData.Address, testAddress, t)
+}
+
+func Test_KVStore_DeleteDataFromUniqueDB_Ascending(t *testing.T) {
+
+	prefix := "somePrefix"
+	genesisHash := "someGenHash"
+
+	messageDBID := []string{prefix, genesisHash, services.MessageDir}
+	messageDBName := services.GetBadgerDBName(messageDBID)
+
+	message := "testMessage"
+
+	services.InitUniqueKvStore(messageDBID)
+	defer services.CloseUniqueKvStore(messageDBName)
+
+	keys := &services.KVKeys{
+		genesisHash + "_1",
+		genesisHash + "_2",
+		genesisHash + "_3",
+		genesisHash + "_4",
+		genesisHash + "_5",
+		genesisHash + "_6",
+	}
+
+	services.BatchSetToUniqueDB(messageDBID,
+		&services.KVPairs{
+			genesisHash + "_1": message + "1",
+			genesisHash + "_2": message + "2",
+			genesisHash + "_3": message + "3",
+			genesisHash + "_4": message + "4",
+			genesisHash + "_5": message + "5",
+			genesisHash + "_6": message + "6"},
+		models.TestValueTimeToLive)
+
+	err := services.DeleteDataFromUniqueDB(messageDBID, genesisHash, 2, 4)
+
+	oyster_utils.AssertNoError(err, t, "Could not delete from db for certain index range")
+
+	kvs, _ := services.BatchGetFromUniqueDB(messageDBID, keys)
+	oyster_utils.AssertTrue(len(*kvs) == 3, t, "")
+
+	foundWhatWeWanted := false
+	designatedKeysAreGone := false
+
+	for _, value := range *kvs {
+		foundWhatWeWanted = strings.Contains(value, "1") || strings.Contains(value, "5") ||
+			strings.Contains(value, "6")
+
+		designatedKeysAreGone = !strings.Contains(value, "2") && !strings.Contains(value, "3") &&
+			!strings.Contains(value, "4")
+
+		oyster_utils.AssertTrue(foundWhatWeWanted, t, "")
+		oyster_utils.AssertTrue(designatedKeysAreGone, t, "")
+	}
+}
+
+func Test_KVStore_DeleteDataFromUniqueDB_Descending(t *testing.T) {
+
+	prefix := "somePrefix"
+	genesisHash := "someGenHash"
+
+	messageDBID := []string{prefix, genesisHash, services.MessageDir}
+	messageDBName := services.GetBadgerDBName(messageDBID)
+
+	message := "testMessage"
+
+	services.InitUniqueKvStore(messageDBID)
+	defer services.CloseUniqueKvStore(messageDBName)
+
+	keys := &services.KVKeys{
+		genesisHash + "_1",
+		genesisHash + "_2",
+		genesisHash + "_3",
+		genesisHash + "_4",
+		genesisHash + "_5",
+		genesisHash + "_6",
+	}
+
+	services.BatchSetToUniqueDB(messageDBID,
+		&services.KVPairs{
+			genesisHash + "_1": message + "1",
+			genesisHash + "_2": message + "2",
+			genesisHash + "_3": message + "3",
+			genesisHash + "_4": message + "4",
+			genesisHash + "_5": message + "5",
+			genesisHash + "_6": message + "6"},
+		models.TestValueTimeToLive)
+
+	err := services.DeleteDataFromUniqueDB(messageDBID, genesisHash, 4, 2)
+
+	oyster_utils.AssertNoError(err, t, "Could not delete from db for certain index range")
+
+	kvs, _ := services.BatchGetFromUniqueDB(messageDBID, keys)
+	oyster_utils.AssertTrue(len(*kvs) == 3, t, "")
+
+	foundWhatWeWanted := false
+	designatedKeysAreGone := false
+
+	for _, value := range *kvs {
+		foundWhatWeWanted = strings.Contains(value, "1") || strings.Contains(value, "5") ||
+			strings.Contains(value, "6")
+
+		designatedKeysAreGone = !strings.Contains(value, "2") && !strings.Contains(value, "3") &&
+			!strings.Contains(value, "4")
+
+		oyster_utils.AssertTrue(foundWhatWeWanted, t, "")
+		oyster_utils.AssertTrue(designatedKeysAreGone, t, "")
+	}
 }

--- a/utils/trytes_conversion.go
+++ b/utils/trytes_conversion.go
@@ -150,6 +150,7 @@ func PadWith9s(stringToPad string, desiredLength int) string {
 	return retStr[0:desiredLength]
 }
 
+/*Sha256ToAddress wraps functionality to turn a sha256 hash into an address*/
 func Sha256ToAddress(hashString string) string {
 	obfuscatedHash := HashHex(hashString, sha512.New384())
 	return string(MakeAddress(obfuscatedHash))

--- a/utils/trytes_conversion.go
+++ b/utils/trytes_conversion.go
@@ -1,6 +1,7 @@
 package oyster_utils
 
 import (
+	"crypto/sha512"
 	"encoding/hex"
 	"errors"
 	"github.com/iotaledger/giota"
@@ -141,11 +142,15 @@ func MakeAddress(hashString string) string {
 		return PadWith9s(result, 81)
 	}
 	return result
-
 }
 
 func PadWith9s(stringToPad string, desiredLength int) string {
 	padCountInt := desiredLength - len(stringToPad)
 	var retStr = stringToPad + strings.Repeat("9", padCountInt)
 	return retStr[0:desiredLength]
+}
+
+func Sha256ToAddress(hashString string) string {
+	obfuscatedHash := HashHex(hashString, sha512.New384())
+	return string(MakeAddress(obfuscatedHash))
 }

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -374,7 +374,7 @@ func IntMax(x, y int) int {
 	return y
 }
 
-/*GenerateMsgID will generate a msg_id for use with badger*/
-func GenerateMsgID(startingString string, genesisHash string, chunkIdx int) string {
+/*GenerateBadgerKey will generate a msg_id for use with badger*/
+func GenerateBadgerKey(startingString string, genesisHash string, chunkIdx int) string {
 	return fmt.Sprintf("%v%v__%d", startingString, genesisHash, chunkIdx)
 }


### PR DESCRIPTION
-adds new methods and tests for KV store

This does not yet implement moving all of data_maps out of SQL.  This just adds new methods to KVStore, and unit tests.  May need to make small changes to these methods with next PR but this should be the bulk of the changes to the kv_store file, aside from pulling out old methods later.