### PR TITLE
Add round robining, only verify when all chunks are attached

### DIFF
--- a/jobs/process_unassigned_chunks_test.go
+++ b/jobs/process_unassigned_chunks_test.go
@@ -82,17 +82,17 @@ func (suite *JobsSuite) Test_ProcessUnassignedChunks() {
 	SessionSetUpForTest(&uploadSession4, []int{15}, uploadSession4.NumChunks)
 
 	// set uploadSession4 to be the oldest
-	err := suite.DB.RawQuery("UPDATE upload_sessions SET created_at = ? WHERE genesis_hash = ?",
+	err := suite.DB.RawQuery("UPDATE upload_sessions SET updated_at = ? WHERE genesis_hash = ?",
 		time.Now().Add(-20*time.Second), uploadSession4.GenesisHash).All(&[]models.UploadSession{})
 	suite.Nil(err)
 
 	// set uploadSession2 to next oldest
-	err = suite.DB.RawQuery("UPDATE upload_sessions SET created_at = ? WHERE genesis_hash = ?",
+	err = suite.DB.RawQuery("UPDATE upload_sessions SET updated_at = ? WHERE genesis_hash = ?",
 		time.Now().Add(-15*time.Second), uploadSession2.GenesisHash).All(&[]models.UploadSession{})
 	suite.Nil(err)
 
 	// set uploadSession1 to next oldest after uploadSession2
-	err = suite.DB.RawQuery("UPDATE upload_sessions SET created_at = ? WHERE genesis_hash = ?",
+	err = suite.DB.RawQuery("UPDATE upload_sessions SET updated_at = ? WHERE genesis_hash = ?",
 		time.Now().Add(-10*time.Second), uploadSession1.GenesisHash).All(&[]models.UploadSession{})
 	suite.Nil(err)
 

--- a/jobs/purge_completed_sessions.go
+++ b/jobs/purge_completed_sessions.go
@@ -2,6 +2,7 @@ package jobs
 
 import (
 	"errors"
+	"fmt"
 	"sync"
 
 	"github.com/gobuffalo/pop"
@@ -83,6 +84,10 @@ func purgeSessions(genesisHash string) {
 		}
 
 		if len(sessions) > 0 {
+
+			fmt.Println("PURGING SESSION!!")
+			fmt.Println(sessions[0])
+
 			errMovingChunks := sessions[0].MoveAllChunksToCompleted()
 			if errMovingChunks != nil {
 				oyster_utils.LogIfError(err, nil)

--- a/jobs/purge_completed_sessions_test.go
+++ b/jobs/purge_completed_sessions_test.go
@@ -74,7 +74,7 @@ func (suite *JobsSuite) Test_PurgeCompletedSessions() {
 	suite.True(finished3)
 
 	// Set all sessions to states that will cause them to be picked up by
-	// GetSessionsByAge
+	// GetSessionsByOldestUpdate
 	sessions := []models.UploadSession{}
 	suite.DB.All(&sessions)
 	for _, session := range sessions {

--- a/jobs/verify_data_maps.go
+++ b/jobs/verify_data_maps.go
@@ -12,7 +12,7 @@ func VerifyDataMaps(IotaWrapper services.IotaService, PrometheusWrapper services
 	start := PrometheusWrapper.TimeNow()
 	defer PrometheusWrapper.HistogramSeconds(PrometheusWrapper.HistogramVerifyDataMaps, start)
 
-	sessions, err := models.GetSessionsByAge()
+	sessions, err := models.GetVerifiableSessions()
 
 	for _, session := range sessions {
 		checkSessionChunks(IotaWrapper, session)

--- a/jobs/verify_data_maps_test.go
+++ b/jobs/verify_data_maps_test.go
@@ -239,11 +239,11 @@ func (suite *JobsSuite) Test_VerifyDataMaps_verify_all_alpha() {
 	uploadSession1.AllDataReady = models.AllDataReady
 	suite.DB.ValidateAndUpdate(uploadSession1)
 
-	uploadSession1.NextIdxToAttach = -1
-	uploadSession1.NextIdxToVerify = int64(uploadSession1.NumChunks - 1)
+	uploadSession1.NextIdxToAttach = int64(uploadSession1.NumChunks)
+	uploadSession1.NextIdxToVerify = 0
 	suite.DB.ValidateAndUpdate(uploadSession1)
 
-	suite.Equal(int64(uploadSession1.NumChunks-1), uploadSession1.NextIdxToVerify)
+	suite.Equal(int64(0), uploadSession1.NextIdxToVerify)
 
 	// call method under test, passing in our mock of our iota methods
 	jobs.VerifyDataMaps(IotaMock, jobs.PrometheusWrapper)
@@ -254,7 +254,7 @@ func (suite *JobsSuite) Test_VerifyDataMaps_verify_all_alpha() {
 	session := models.UploadSession{}
 	suite.DB.First(&session)
 
-	suite.Equal(int64(-1), session.NextIdxToVerify)
+	suite.Equal(int64(uploadSession1.NumChunks), session.NextIdxToVerify)
 	suite.True(verifyChunkMessagesMatchesRecordMockCalled_verify)
 }
 
@@ -324,11 +324,11 @@ func (suite *JobsSuite) Test_VerifyDataMaps_verify_some_alpha() {
 	session.AllDataReady = models.AllDataReady
 	suite.DB.ValidateAndUpdate(&session)
 
-	session.NextIdxToAttach = -1
-	session.NextIdxToVerify = int64(session.NumChunks - 1)
+	session.NextIdxToAttach = int64(session.NumChunks)
+	session.NextIdxToVerify = 0
 	suite.DB.ValidateAndUpdate(&session)
 
-	suite.Equal(int64(session.NumChunks-1), session.NextIdxToVerify)
+	suite.Equal(int64(0), session.NextIdxToVerify)
 
 	// call method under test, passing in our mock of our iota methods
 	jobs.VerifyDataMaps(IotaMock, jobs.PrometheusWrapper)
@@ -339,7 +339,6 @@ func (suite *JobsSuite) Test_VerifyDataMaps_verify_some_alpha() {
 	session = models.UploadSession{}
 	suite.DB.First(&session)
 
-	suite.Equal(int64(-1), session.NextIdxToVerify)
-
-	suite.True(verifyChunkMessagesMatchesRecordMockCalled_verify)
+	// we only set 3 to be matching the tangle
+	suite.Equal(int64(3), session.NextIdxToVerify)
 }

--- a/services/eth_gateway.go
+++ b/services/eth_gateway.go
@@ -353,7 +353,7 @@ func generateEthAddr() (addr common.Address, privateKey string, err error) {
 	}
 	addr = crypto.PubkeyToAddress(ethAccount.PublicKey)
 	privateKey = hex.EncodeToString(ethAccount.D.Bytes())
-	if privateKey[0] == '0' || len(privateKey) != 64 {
+	if privateKey[0] == '0' || len(privateKey) != 64 || len(addr) != 20 {
 		return generateEthAddr()
 	}
 	return addr, privateKey, err


### PR DESCRIPTION
-Changes the order of verification.  Previously verification could occur while a file was still being attached.  This caused some redundant attachments.  Now we will wait until the broker thinks it has already attached all chunks before we bother verifying the attachment, which dramatically cuts down on redundancy.  

-Round robin - changes the method of selecting sessions for chunk processing by selecting the session with the oldest update time rather than the oldest creation time.  Since we are constantly updating sessions with a new `NextIdxToAttach` value, the `updated_at` times for sessions will always be changing and every session will periodically be the oldest session (in terms of `updated_at` time).  This means all active sessions will get some attention instead of just the oldest.  

-Adds an extra check to the `generateEthAddr` method to make sure we have valid return values.  

-Change `GetSessionsByAge` to `GetSessionsByOldestUpdateTime` for clarity.   

-Update unit tests.  