### PR TITLE
Hex panic

### DIFF
--- a/jobs/job_runner.go
+++ b/jobs/job_runner.go
@@ -130,8 +130,9 @@ func purgeCompletedSessionsHandler(args worker.Args) error {
 }
 
 func verifyDataMapsHandler(args worker.Args) error {
+	thresholdTime := time.Now().Add(-3 * time.Minute) // wait 3 minutes before verifying a file
 	if os.Getenv("TANGLE_MAINTENANCE") != "true" {
-		VerifyDataMaps(IotaWrapper, PrometheusWrapper)
+		VerifyDataMaps(IotaWrapper, PrometheusWrapper, thresholdTime)
 	}
 
 	oysterWorkerPerformIn(verifyDataMapsHandler, args)

--- a/jobs/process_unassigned_chunks.go
+++ b/jobs/process_unassigned_chunks.go
@@ -49,7 +49,7 @@ func GetSessionUnassignedChunks(sessions []models.UploadSession, iotaWrapper ser
 				Set("num_ready_channels", len(channels)))
 		}
 
-		if len(chunks) == len(channels)*BundleSize {
+		if len(chunks) >= len(channels)*BundleSize {
 			// we have used up all the channels, no point in doing the for loop again
 			break
 		}

--- a/jobs/process_unassigned_chunks_test.go
+++ b/jobs/process_unassigned_chunks_test.go
@@ -13,6 +13,7 @@ var (
 	sendChunksToChannelMockCalled_process_unassigned_chunks              = false
 	verifyChunkMessagesMatchesRecordMockCalled_process_unassigned_chunks = false
 	findTransactionsMockCalled_process_unassigned_chunks                 = false
+	sendChunksToLambdaMockCalled_process_unassigned_chunks               = false
 	AllChunksCalled                                                      []oyster_utils.ChunkData
 	fakeFindTransactionsAddress                                          = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
 )
@@ -101,7 +102,7 @@ func (suite *JobsSuite) Test_ProcessUnassignedChunks() {
 	// call method under test
 	jobs.ProcessUnassignedChunks(IotaMock, jobs.PrometheusWrapper)
 
-	suite.True(sendChunksToChannelMockCalled_process_unassigned_chunks)
+	suite.True(sendChunksToChannelMockCalled_process_unassigned_chunks || sendChunksToLambdaMockCalled_process_unassigned_chunks)
 	suite.True(verifyChunkMessagesMatchesRecordMockCalled_process_unassigned_chunks)
 	suite.Equal(4*(uploadSession1.NumChunks), len(AllChunksCalled))
 
@@ -451,6 +452,7 @@ func makeMocks_process_unassigned_chunks(iotaMock *services.IotaService) {
 	iotaMock.VerifyChunkMessagesMatchRecord = verifyChunkMessagesMatchesRecordMock_process_unassigned_chunks
 	iotaMock.SendChunksToChannel = sendChunksToChannelMock_process_unassigned_chunks
 	iotaMock.FindTransactions = findTransactions_process_unassigned_chunks
+	iotaMock.SendChunksToLambda = sendChunksToLambda_process_unassigned_chunks
 }
 
 func sendChunksToChannelMock_process_unassigned_chunks(chunks []oyster_utils.ChunkData, channel *models.ChunkChannel) {
@@ -493,4 +495,11 @@ func findTransactions_process_unassigned_chunks(addresses []giota.Address) (map[
 	findTransactionsMockCalled_process_unassigned_chunks = true
 
 	return addrToTransactionMap, nil
+}
+
+func sendChunksToLambda_process_unassigned_chunks(chunks *[]oyster_utils.ChunkData) {
+	sendChunksToLambdaMockCalled_process_unassigned_chunks = true
+
+	// stored all the chunks that get sent to the mock so we can run tests on them.
+	AllChunksCalled = append(AllChunksCalled, *chunks...)
 }

--- a/jobs/verify_data_maps.go
+++ b/jobs/verify_data_maps.go
@@ -8,6 +8,8 @@ import (
 	"time"
 )
 
+/*VerifyDataMaps will check sessions for which attachment has been completed, to make sure the chunks
+have been attached to the tangle.*/
 func VerifyDataMaps(IotaWrapper services.IotaService, PrometheusWrapper services.PrometheusService, thresholdTime time.Time) {
 
 	start := PrometheusWrapper.TimeNow()

--- a/jobs/verify_data_maps.go
+++ b/jobs/verify_data_maps.go
@@ -5,14 +5,15 @@ import (
 	"github.com/oysterprotocol/brokernode/models"
 	"github.com/oysterprotocol/brokernode/services"
 	"github.com/oysterprotocol/brokernode/utils"
+	"time"
 )
 
-func VerifyDataMaps(IotaWrapper services.IotaService, PrometheusWrapper services.PrometheusService) {
+func VerifyDataMaps(IotaWrapper services.IotaService, PrometheusWrapper services.PrometheusService, thresholdTime time.Time) {
 
 	start := PrometheusWrapper.TimeNow()
 	defer PrometheusWrapper.HistogramSeconds(PrometheusWrapper.HistogramVerifyDataMaps, start)
 
-	sessions, err := models.GetVerifiableSessions()
+	sessions, err := models.GetVerifiableSessions(thresholdTime)
 
 	for _, session := range sessions {
 		checkSessionChunks(IotaWrapper, session)

--- a/jobs/verify_data_maps_test.go
+++ b/jobs/verify_data_maps_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/oysterprotocol/brokernode/models"
 	"github.com/oysterprotocol/brokernode/services"
 	"github.com/oysterprotocol/brokernode/utils"
+	"time"
 )
 
 var (
@@ -81,7 +82,7 @@ func (suite *JobsSuite) Test_VerifyDataMaps_verify_all_beta() {
 	suite.Equal(int64(session.NumChunks-1), session.NextIdxToVerify)
 
 	// call method under test, passing in our mock of our iota methods
-	jobs.VerifyDataMaps(IotaMock, jobs.PrometheusWrapper)
+	jobs.VerifyDataMaps(IotaMock, jobs.PrometheusWrapper, time.Now().Add(1*time.Minute))
 
 	// verify the mock methods were called
 	suite.True(verifyChunkMessagesMatchesRecordMockCalled_verify)
@@ -167,7 +168,7 @@ func (suite *JobsSuite) Test_VerifyDataMaps_verify_some_beta() {
 	suite.Equal(int64(session.NumChunks-1), session.NextIdxToVerify)
 
 	// call method under test, passing in our mock of our iota methods
-	jobs.VerifyDataMaps(IotaMock, jobs.PrometheusWrapper)
+	jobs.VerifyDataMaps(IotaMock, jobs.PrometheusWrapper, time.Now().Add(1*time.Minute))
 
 	// verify the mock methods were called
 	suite.True(verifyChunkMessagesMatchesRecordMockCalled_verify)
@@ -246,7 +247,7 @@ func (suite *JobsSuite) Test_VerifyDataMaps_verify_all_alpha() {
 	suite.Equal(int64(0), uploadSession1.NextIdxToVerify)
 
 	// call method under test, passing in our mock of our iota methods
-	jobs.VerifyDataMaps(IotaMock, jobs.PrometheusWrapper)
+	jobs.VerifyDataMaps(IotaMock, jobs.PrometheusWrapper, time.Now().Add(1*time.Minute))
 
 	// verify the mock methods were called
 	suite.True(verifyChunkMessagesMatchesRecordMockCalled_verify)
@@ -331,7 +332,7 @@ func (suite *JobsSuite) Test_VerifyDataMaps_verify_some_alpha() {
 	suite.Equal(int64(0), session.NextIdxToVerify)
 
 	// call method under test, passing in our mock of our iota methods
-	jobs.VerifyDataMaps(IotaMock, jobs.PrometheusWrapper)
+	jobs.VerifyDataMaps(IotaMock, jobs.PrometheusWrapper, time.Now().Add(1*time.Minute))
 
 	// verify the mock methods were called
 	suite.True(verifyChunkMessagesMatchesRecordMockCalled_verify)

--- a/models/upload_sessions.go
+++ b/models/upload_sessions.go
@@ -995,14 +995,14 @@ func (u *UploadSession) UpdateIndexWithVerifiedChunks(chunks []oyster_utils.Chun
 	}
 
 	for i := nextIdxToVerifyStart; i != nextIdxToVerifyStart+(int64(len(chunks))*step); i = i + step {
-		if _, ok := treasureIdxMap[i]; !ok {
-			if _, ok := idxMap[i]; !ok {
+		if _, ok := idxMap[i]; !ok {
+			if _, ok := treasureIdxMap[i]; !ok {
 				break
-			}
-		} else {
-			chunk := GetSingleChunkData(oyster_utils.CompletedDir, u.GenesisHash, int64(i))
-			if chunk.Hash == "" {
-				break
+			} else {
+				chunk := GetSingleChunkData(oyster_utils.CompletedDir, u.GenesisHash, int64(i))
+				if chunk.Hash == "" {
+					break
+				}
 			}
 		}
 		nextIdxToVerifyNew = i + step
@@ -1052,14 +1052,14 @@ func (u *UploadSession) UpdateIndexWithAttachedChunks(chunks []oyster_utils.Chun
 	}
 
 	for i := nextIdxToAttachStart; i != nextIdxToAttachStart+(int64(len(chunks))*step); i = i + step {
-		if _, ok := treasureIdxMap[i]; !ok {
-			if _, ok := idxMap[i]; !ok {
+		if _, ok := idxMap[i]; !ok {
+			if _, ok := treasureIdxMap[i]; !ok {
 				break
-			}
-		} else {
-			chunk := GetSingleChunkData(oyster_utils.CompletedDir, u.GenesisHash, int64(i))
-			if chunk.Hash == "" {
-				break
+			} else {
+				chunk := GetSingleChunkData(oyster_utils.CompletedDir, u.GenesisHash, int64(i))
+				if chunk.Hash == "" {
+					break
+				}
 			}
 		}
 		nextIdxToAttachNew = i + step

--- a/models/upload_sessions.go
+++ b/models/upload_sessions.go
@@ -490,6 +490,7 @@ func (u *UploadSession) SetTreasureMap(treasureIndexMap []TreasureMap) error {
 func (u *UploadSession) MakeTreasureIdxMap(mergedIndexes []int, privateKeys []string) {
 
 	treasureIndexArray := make([]TreasureMap, 0)
+	successfulEncryption := true
 
 	for i, mergedIndex := range mergedIndexes {
 
@@ -505,17 +506,25 @@ func (u *UploadSession) MakeTreasureIdxMap(mergedIndexes []int, privateKeys []st
 			Idx:    mergedIndex,
 			Key:    key,
 		})
+
+		decryptedKey, err := u.DecryptTreasureChunkEthKey(key)
+		if decryptedKey == "" {
+			successfulEncryption = false
+		}
 	}
 
-	treasureString, err := json.Marshal(treasureIndexArray)
-	if err != nil {
-		oyster_utils.LogIfError(err, nil)
+	if successfulEncryption {
+
+		treasureString, err := json.Marshal(treasureIndexArray)
+		if err != nil {
+			oyster_utils.LogIfError(err, nil)
+		}
+
+		u.TreasureIdxMap = nulls.String{string(treasureString), true}
+		u.TreasureStatus = TreasureInDataMapPending
+
+		DB.ValidateAndSave(u)
 	}
-
-	u.TreasureIdxMap = nulls.String{string(treasureString), true}
-	u.TreasureStatus = TreasureInDataMapPending
-
-	DB.ValidateAndSave(u)
 }
 
 func (u *UploadSession) GetTreasureIndexes() ([]int, error) {
@@ -1179,11 +1188,20 @@ func GetReadySessions() ([]UploadSession, error) {
 
 /*GetVerifiableSessions gets all the sessions which we have already attached all the chunks for but which still need
 verification.*/
-func GetVerifiableSessions() ([]UploadSession, error) {
+func GetVerifiableSessions(thresholdTime time.Time) ([]UploadSession, error) {
+
 	sessions := []UploadSession{}
 	verifiableSessions := []UploadSession{}
 
-	sessions, err := GetSessionsByOldestUpdate()
+	err := DB.RawQuery("SELECT * FROM upload_sessions WHERE payment_status = ? AND "+
+		"treasure_status = ? AND all_data_ready = ? AND updated_at <= ? ORDER BY updated_at ASC",
+		PaymentStatusConfirmed, TreasureInDataMapComplete, AllDataReady,
+		thresholdTime).All(&sessions)
+
+	if err != nil {
+		oyster_utils.LogIfError(err, nil)
+		return []UploadSession{}, err
+	}
 
 	for _, session := range sessions {
 		if session.Type == SessionTypeBeta &&


### PR DESCRIPTION
-Adds changes to try to address the hex panic error.  I only ever encountered this issue on the prod brokers, not on my dev machines.  But I've added checking to all the obvious places where the error could be originating
-Delay session verification by several (3) minutes.  Should be plenty of time to allow any outstanding lambda requests to complete and for the TXs to show up on the tangle.  
-Updates unit tests for changes
-Adds a mock for sendChunksToLambda