### PR TITLE
Remove LooseSlash in the buffalo setting

### DIFF
--- a/actions/utils/setup_app.go
+++ b/actions/utils/setup_app.go
@@ -24,7 +24,6 @@ var ENV = envy.Get("GO_ENV", "development")
 func CreateBuffaloApp() *buffalo.App {
 	app := buffalo.New(buffalo.Options{
 		Env:          ENV,
-		LooseSlash:   true,
 		SessionStore: sessions.Null{},
 		PreWares: []buffalo.PreWare{
 			cors.AllowAll().Handler,


### PR DESCRIPTION
See here:https://gobuffalo.io/en/docs/routing#loose-slash

LooseSlash option has been removed and it would cause travis build break. Remove this option completely since the new version will by default turn this on.