### PR TITLE
Moves eth_gateway into utils and change all imports

### DIFF
--- a/actions/v2/actions.go
+++ b/actions/v2/actions.go
@@ -3,11 +3,12 @@ package actions_v2
 import (
 	"github.com/gobuffalo/buffalo"
 	"github.com/oysterprotocol/brokernode/services"
+	"github.com/oysterprotocol/brokernode/utils/eth_gateway"
 )
 
 // Visible for Unit Test
 var IotaWrapper = services.IotaWrapper
-var EthWrapper = services.EthWrapper
+var EthWrapper = eth_gateway.EthWrapper
 var PrometheusWrapper = services.PrometheusWrapper
 
 func RegisterApi(app *buffalo.App) *buffalo.App {

--- a/actions/v2/actions_test.go
+++ b/actions/v2/actions_test.go
@@ -1,6 +1,7 @@
 package actions_v2
 
 import (
+	"github.com/oysterprotocol/brokernode/utils/eth_gateway"
 	"testing"
 
 	"github.com/gobuffalo/suite"
@@ -18,7 +19,7 @@ func (suite *ActionSuite) SetupTest() {
 
 	suite.Nil(oyster_utils.InitKvStore())
 
-	EthWrapper = services.EthWrapper
+	EthWrapper = eth_gateway.EthWrapper
 	IotaWrapper = services.IotaWrapper
 }
 

--- a/actions/v2/treasures_test.go
+++ b/actions/v2/treasures_test.go
@@ -3,6 +3,7 @@ package actions_v2
 import (
 	"encoding/json"
 	"errors"
+	"github.com/oysterprotocol/brokernode/utils/eth_gateway"
 	"io/ioutil"
 	"math/big"
 
@@ -31,7 +32,7 @@ func (suite *ActionSuite) Test_VerifyTreasureAndClaim_Success() {
 	IotaWrapper = services.IotaService{
 		VerifyTreasure: mockVerifyTreasure.verifyTreasure,
 	}
-	EthWrapper = services.Eth{
+	EthWrapper = eth_gateway.Eth{
 		GenerateEthAddrFromPrivateKey: EthWrapper.GenerateEthAddrFromPrivateKey,
 		CheckClaimClock: func(address common.Address) (*big.Int, error) {
 			checkClaimClockCalled = true
@@ -41,7 +42,7 @@ func (suite *ActionSuite) Test_VerifyTreasureAndClaim_Success() {
 	}
 
 	ethKey := "9999999999999999999999999999999999999999999999999999999999999991"
-	addr := services.EthWrapper.GenerateEthAddrFromPrivateKey(ethKey)
+	addr := eth_gateway.EthWrapper.GenerateEthAddrFromPrivateKey(ethKey)
 
 	res := suite.JSON("/api/v2/treasures").Post(map[string]interface{}{
 		"receiverEthAddr": addr,
@@ -83,7 +84,7 @@ func (suite *ActionSuite) Test_VerifyTreasure_FailureWithError() {
 	}
 
 	ethKey := "9999999999999999999999999999999999999999999999999999999999999991"
-	addr := services.EthWrapper.GenerateEthAddrFromPrivateKey(ethKey)
+	addr := eth_gateway.EthWrapper.GenerateEthAddrFromPrivateKey(ethKey)
 
 	res := suite.JSON("/api/v2/treasures").Post(map[string]interface{}{
 		"receiverEthAddr": addr,
@@ -116,7 +117,7 @@ func (suite *ActionSuite) Test_Check_Claim_Clock_Error() {
 	IotaWrapper = services.IotaService{
 		VerifyTreasure: mockVerifyTreasure.verifyTreasure,
 	}
-	EthWrapper = services.Eth{
+	EthWrapper = eth_gateway.Eth{
 		GenerateEthAddrFromPrivateKey: EthWrapper.GenerateEthAddrFromPrivateKey,
 		CheckClaimClock: func(address common.Address) (*big.Int, error) {
 			ethAddressCalledWithCheckClaimClock = address
@@ -126,7 +127,7 @@ func (suite *ActionSuite) Test_Check_Claim_Clock_Error() {
 	}
 
 	ethKey := "9999999999999999999999999999999999999999999999999999999999999991"
-	addr := services.EthWrapper.GenerateEthAddrFromPrivateKey(ethKey)
+	addr := eth_gateway.EthWrapper.GenerateEthAddrFromPrivateKey(ethKey)
 
 	res := suite.JSON("/api/v2/treasures").Post(map[string]interface{}{
 		"receiverEthAddr": addr,

--- a/actions/v2/upload_sessions.go
+++ b/actions/v2/upload_sessions.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"github.com/oysterprotocol/brokernode/utils/eth_gateway"
 	"net/http"
 	"os"
 	"strconv"
@@ -13,7 +14,6 @@ import (
 	"github.com/gobuffalo/pop/nulls"
 	"github.com/oysterprotocol/brokernode/actions/utils"
 	"github.com/oysterprotocol/brokernode/models"
-	"github.com/oysterprotocol/brokernode/services"
 	"github.com/oysterprotocol/brokernode/utils"
 	"github.com/pkg/errors"
 	"gopkg.in/segmentio/analytics-go.v3"
@@ -444,7 +444,7 @@ func (usr *UploadSessionResourceV2) GetPaymentStatus(c buffalo.Context) error {
 
 	// Force to check the status
 	if session.PaymentStatus != models.PaymentStatusConfirmed {
-		balance := EthWrapper.CheckPRLBalance(services.StringToAddress(session.ETHAddrAlpha.String))
+		balance := EthWrapper.CheckPRLBalance(eth_gateway.StringToAddress(session.ETHAddrAlpha.String))
 		if balance.Int64() > 0 {
 			previousPaymentStatus := session.PaymentStatus
 			session.PaymentStatus = models.PaymentStatusConfirmed

--- a/actions/v3/actions.go
+++ b/actions/v3/actions.go
@@ -3,11 +3,12 @@ package actions_v3
 import (
 	"github.com/gobuffalo/buffalo"
 	"github.com/oysterprotocol/brokernode/services"
+	"github.com/oysterprotocol/brokernode/utils/eth_gateway"
 )
 
 // Visible for Unit Test
 var IotaWrapper = services.IotaWrapper
-var EthWrapper = services.EthWrapper
+var EthWrapper = eth_gateway.EthWrapper
 var PrometheusWrapper = services.PrometheusWrapper
 
 func RegisterApi(app *buffalo.App) *buffalo.App {

--- a/actions/v3/actions_test.go
+++ b/actions/v3/actions_test.go
@@ -1,6 +1,7 @@
 package actions_v3
 
 import (
+	"github.com/oysterprotocol/brokernode/utils/eth_gateway"
 	"testing"
 
 	"github.com/gobuffalo/suite"
@@ -18,7 +19,7 @@ func (suite *ActionSuite) SetupTest() {
 
 	suite.Nil(oyster_utils.InitKvStore())
 
-	EthWrapper = services.EthWrapper
+	EthWrapper = eth_gateway.EthWrapper
 	IotaWrapper = services.IotaWrapper
 }
 

--- a/grifts/db.go
+++ b/grifts/db.go
@@ -8,8 +8,8 @@ import (
 	"github.com/markbates/grift/grift"
 	"github.com/oysterprotocol/brokernode/jobs"
 	"github.com/oysterprotocol/brokernode/models"
-	"github.com/oysterprotocol/brokernode/services"
 	"github.com/oysterprotocol/brokernode/utils"
+	"github.com/oysterprotocol/brokernode/utils/eth_gateway"
 	"github.com/shopspring/decimal"
 	"math/big"
 	"os"
@@ -25,9 +25,9 @@ func getAddress() (common.Address, string, error) {
 	if griftPrivateKey == "" {
 		errorString := "you haven't specified an eth private key to use for this grift"
 		fmt.Println(errorString)
-		return services.StringToAddress(""), griftPrivateKey, errors.New(errorString)
+		return eth_gateway.StringToAddress(""), griftPrivateKey, errors.New(errorString)
 	}
-	address := services.EthWrapper.GenerateEthAddrFromPrivateKey(griftPrivateKey)
+	address := eth_gateway.EthWrapper.GenerateEthAddrFromPrivateKey(griftPrivateKey)
 	return address, griftPrivateKey, nil
 }
 
@@ -132,7 +132,7 @@ var _ = grift.Namespace("db", func() {
 		}
 
 		for i := 0; i < numToCreate; i++ {
-			address, griftPrivateKey, err := services.EthWrapper.GenerateEthAddr()
+			address, griftPrivateKey, err := eth_gateway.EthWrapper.GenerateEthAddr()
 			fmt.Println("PRIVATE KEY IS:")
 			fmt.Println(griftPrivateKey)
 
@@ -531,7 +531,7 @@ var _ = grift.Namespace("db", func() {
 		}
 
 		for i := 0; i < numToCreate; i++ {
-			address, griftPrivateKey, err := services.EthWrapper.GenerateEthAddr()
+			address, griftPrivateKey, err := eth_gateway.EthWrapper.GenerateEthAddr()
 			fmt.Println("PRIVATE KEY IS:")
 			fmt.Println(griftPrivateKey)
 
@@ -545,16 +545,16 @@ var _ = grift.Namespace("db", func() {
 			prlAmount := big.NewFloat(float64(.0001))
 			prlAmountInWei := oyster_utils.ConvertToWeiUnit(prlAmount)
 
-			callMsg, _ := services.EthWrapper.CreateSendPRLMessage(services.MainWalletAddress,
-				services.MainWalletPrivateKey,
+			callMsg, _ := eth_gateway.EthWrapper.CreateSendPRLMessage(eth_gateway.MainWalletAddress,
+				eth_gateway.MainWalletPrivateKey,
 				address, *prlAmountInWei)
 
-			sendSuccess, _, _ := services.EthWrapper.SendPRLFromOyster(callMsg)
+			sendSuccess, _, _ := eth_gateway.EthWrapper.SendPRLFromOyster(callMsg)
 			if sendSuccess {
 				fmt.Println("Sent successfully!")
 				for {
 					fmt.Println("Polling for PRL arrival")
-					balance := services.EthWrapper.CheckPRLBalance(address)
+					balance := eth_gateway.EthWrapper.CheckPRLBalance(address)
 					if balance.Int64() > 0 {
 						fmt.Println("PRL arrived!")
 						break
@@ -710,7 +710,7 @@ var _ = grift.Namespace("db", func() {
 		}
 
 		for i := 0; i < numToCreate; i++ {
-			address, privateKey, err := services.EthWrapper.GenerateEthAddr()
+			address, privateKey, err := eth_gateway.EthWrapper.GenerateEthAddr()
 			fmt.Println("PRIVATE KEY IS:")
 			fmt.Println(privateKey)
 
@@ -739,7 +739,7 @@ var _ = grift.Namespace("db", func() {
 			}
 
 			for {
-				buried, err := services.EthWrapper.CheckBuriedState(address)
+				buried, err := eth_gateway.EthWrapper.CheckBuriedState(address)
 				if err != nil {
 					fmt.Println("ERROR CHECKING BURIED STATE!")
 					return err
@@ -821,8 +821,8 @@ var _ = grift.Namespace("db", func() {
 				fmt.Println("Gas Status:             " + models.GasTransferStatusMap[treasureClaim.GasStatus])
 				fmt.Println("Starting Claim Clock:   " + big.NewInt(treasureClaim.StartingClaimClock).String())
 
-				claimClock, _ := services.EthWrapper.CheckClaimClock(
-					services.StringToAddress(treasureClaim.TreasureETHAddr))
+				claimClock, _ := eth_gateway.EthWrapper.CheckClaimClock(
+					eth_gateway.StringToAddress(treasureClaim.TreasureETHAddr))
 
 				fmt.Println("Current Claim Clock:    " + claimClock.String())
 				fmt.Println("________________________________________________________")
@@ -873,8 +873,8 @@ var _ = grift.Namespace("db", func() {
 	grift.Desc("test_broker_txs", "Tests check_alpha_payments and check_beta_payments")
 	grift.Add("test_broker_txs", func(c *grift.Context) error {
 
-		alphaAddr, key, _ := services.EthWrapper.GenerateEthAddr()
-		betaAddr, betaKey, _ := services.EthWrapper.GenerateEthAddr()
+		alphaAddr, key, _ := eth_gateway.EthWrapper.GenerateEthAddr()
+		betaAddr, betaKey, _ := eth_gateway.EthWrapper.GenerateEthAddr()
 
 		validChars := []rune("abcde123456789")
 		genesisHashEndingCharsAlpha := oyster_utils.RandSeq(10, validChars)
@@ -926,12 +926,12 @@ var _ = grift.Namespace("db", func() {
 			return err
 		}
 
-		callMsg, _ := services.EthWrapper.CreateSendPRLMessage(
-			services.MainWalletAddress,
-			services.MainWalletPrivateKey,
-			services.StringToAddress(brokerTxAlpha.ETHAddrAlpha), *totalCostInWei)
+		callMsg, _ := eth_gateway.EthWrapper.CreateSendPRLMessage(
+			eth_gateway.MainWalletAddress,
+			eth_gateway.MainWalletPrivateKey,
+			eth_gateway.StringToAddress(brokerTxAlpha.ETHAddrAlpha), *totalCostInWei)
 
-		sendSuccess, _, _ := services.EthWrapper.SendPRLFromOyster(callMsg)
+		sendSuccess, _, _ := eth_gateway.EthWrapper.SendPRLFromOyster(callMsg)
 
 		if !sendSuccess {
 			fmt.Println(err)
@@ -1085,7 +1085,7 @@ var _ = grift.Namespace("db", func() {
 	grift.Desc("create_completed_upload", "create a completed upload")
 	grift.Add("create_completed_upload", func(c *grift.Context) error {
 
-		address, privateKey, err := services.EthWrapper.GenerateEthAddr()
+		address, privateKey, err := eth_gateway.EthWrapper.GenerateEthAddr()
 		fmt.Println("PRIVATE KEY IS:")
 		fmt.Println(privateKey)
 

--- a/jobs/bury_treasure_addresses.go
+++ b/jobs/bury_treasure_addresses.go
@@ -6,6 +6,7 @@ import (
 	"github.com/oysterprotocol/brokernode/models"
 	"github.com/oysterprotocol/brokernode/services"
 	"github.com/oysterprotocol/brokernode/utils"
+	"github.com/oysterprotocol/brokernode/utils/eth_gateway"
 	"gopkg.in/segmentio/analytics-go.v3"
 	"time"
 )
@@ -52,7 +53,7 @@ func CheckPRLTransactions() {
 	}
 
 	for _, pending := range prlsPending {
-		prlBalance := EthWrapper.CheckPRLBalance(services.StringToAddress(pending.ETHAddr))
+		prlBalance := EthWrapper.CheckPRLBalance(eth_gateway.StringToAddress(pending.ETHAddr))
 		expectedPRLBalance := pending.GetPRLAmount()
 		if prlBalance.Int64() > 0 && prlBalance.String() == expectedPRLBalance.String() ||
 			prlBalance.Int64() >= expectedPRLBalance.Int64() {
@@ -84,7 +85,7 @@ func CheckGasTransactions() {
 	}
 
 	for _, pending := range gasPending {
-		ethBalance := EthWrapper.CheckETHBalance(services.StringToAddress(pending.ETHAddr))
+		ethBalance := EthWrapper.CheckETHBalance(eth_gateway.StringToAddress(pending.ETHAddr))
 		if ethBalance.Int64() > 0 {
 			fmt.Println("ETH (gas) transaction confirmed in CheckGasTransactions()")
 			pending.PRLStatus = models.GasConfirmed
@@ -114,7 +115,7 @@ func CheckBuryTransactions() {
 	}
 
 	for _, pending := range buryPending {
-		buried, err := EthWrapper.CheckBuriedState(services.StringToAddress(pending.ETHAddr))
+		buried, err := EthWrapper.CheckBuriedState(eth_gateway.StringToAddress(pending.ETHAddr))
 		if err != nil {
 			oyster_utils.LogIfError(err, nil)
 			continue
@@ -161,7 +162,7 @@ func CheckForReclaimableGas(thresholdTime time.Time) {
 
 	for _, reclaimable := range reclaimableAddresses {
 		worthReclaimingGas, gasToReclaim, err := EthWrapper.CheckIfWorthReclaimingGas(
-			services.StringToAddress(reclaimable.ETHAddr), services.GasLimitETHSend)
+			eth_gateway.StringToAddress(reclaimable.ETHAddr), eth_gateway.GasLimitETHSend)
 		if err != nil {
 			fmt.Println("Error determining if it's worth it to retrieve leftover ETH from " +
 				reclaimable.ETHAddr +
@@ -186,9 +187,9 @@ func CheckForReclaimableGas(thresholdTime time.Time) {
 			continue
 		}
 
-		privateKey, err := services.StringToPrivateKey(reclaimable.DecryptTreasureEthKey())
+		privateKey, err := eth_gateway.StringToPrivateKey(reclaimable.DecryptTreasureEthKey())
 
-		reclaimingSuccess := EthWrapper.ReclaimGas(services.StringToAddress(reclaimable.ETHAddr),
+		reclaimingSuccess := EthWrapper.ReclaimGas(eth_gateway.StringToAddress(reclaimable.ETHAddr),
 			privateKey, gasToReclaim)
 
 		if reclaimingSuccess {
@@ -345,7 +346,7 @@ func PurgeFinishedTreasure() {
 
 func sendPRL(treasureToBury models.Treasure) {
 
-	balance := EthWrapper.CheckPRLBalance(services.MainWalletAddress)
+	balance := EthWrapper.CheckPRLBalance(eth_gateway.MainWalletAddress)
 	if balance.Int64() <= 0 || balance.Int64() < treasureToBury.GetPRLAmount().Int64() {
 		errorString := "Cannot send PRL to treasure address due to insufficient balance in wallet.  balance: " +
 			fmt.Sprint(balance.Int64()) + "; amount_to_send: " + fmt.Sprint(treasureToBury.GetPRLAmount().Int64())
@@ -356,9 +357,9 @@ func sendPRL(treasureToBury models.Treasure) {
 
 	amount := *treasureToBury.GetPRLAmount()
 
-	callMsg, _ := EthWrapper.CreateSendPRLMessage(services.MainWalletAddress,
-		services.MainWalletPrivateKey,
-		services.StringToAddress(treasureToBury.ETHAddr), amount)
+	callMsg, _ := EthWrapper.CreateSendPRLMessage(eth_gateway.MainWalletAddress,
+		eth_gateway.MainWalletPrivateKey,
+		eth_gateway.StringToAddress(treasureToBury.ETHAddr), amount)
 
 	sendSuccess, txHash, nonce := EthWrapper.SendPRLFromOyster(callMsg)
 	if !sendSuccess {
@@ -393,14 +394,14 @@ func sendPRL(treasureToBury models.Treasure) {
 
 func sendGas(treasureToBury models.Treasure) {
 
-	gasToSend, err := EthWrapper.CalculateGasNeeded(services.GasLimitPRLBury)
+	gasToSend, err := EthWrapper.CalculateGasNeeded(eth_gateway.GasLimitPRLBury)
 	if err != nil {
 		fmt.Println("Cannot send Gas to treasure address: " + err.Error())
 		// already captured error in upstream function
 		return
 	}
 
-	balance := EthWrapper.CheckETHBalance(services.MainWalletAddress)
+	balance := EthWrapper.CheckETHBalance(eth_gateway.MainWalletAddress)
 	if balance.Int64() < gasToSend.Int64() {
 		errorString := "Cannot send Gas to treasure address due to insufficient balance in wallet.  balance: " +
 			fmt.Sprint(balance.Int64()) + "; amount_to_send: " + fmt.Sprint(gasToSend.Int64())
@@ -409,7 +410,7 @@ func sendGas(treasureToBury models.Treasure) {
 		return
 	}
 
-	_, txHash, nonce, err := EthWrapper.SendETH(services.MainWalletAddress, services.MainWalletPrivateKey, services.StringToAddress(treasureToBury.ETHAddr), gasToSend)
+	_, txHash, nonce, err := EthWrapper.SendETH(eth_gateway.MainWalletAddress, eth_gateway.MainWalletPrivateKey, eth_gateway.StringToAddress(treasureToBury.ETHAddr), gasToSend)
 	if err != nil {
 		errorString := "\nFailure sending " + fmt.Sprint(gasToSend.Int64()) + " Gas to " + treasureToBury.ETHAddr
 		err := errors.New(errorString)
@@ -441,8 +442,8 @@ func sendGas(treasureToBury models.Treasure) {
 
 func buryPRL(treasureToBury models.Treasure) {
 
-	balanceOfPRL := EthWrapper.CheckPRLBalance(services.StringToAddress(treasureToBury.ETHAddr))
-	balanceOfETH := EthWrapper.CheckETHBalance(services.StringToAddress(treasureToBury.ETHAddr))
+	balanceOfPRL := EthWrapper.CheckPRLBalance(eth_gateway.StringToAddress(treasureToBury.ETHAddr))
+	balanceOfETH := EthWrapper.CheckETHBalance(eth_gateway.StringToAddress(treasureToBury.ETHAddr))
 
 	if balanceOfPRL.Int64() <= 0 || balanceOfETH.Int64() <= 0 {
 		errorString := "Cannot bury treasure address due to insufficient balance in treasure wallet (" +
@@ -453,14 +454,14 @@ func buryPRL(treasureToBury models.Treasure) {
 		return
 	}
 
-	privateKey, err := services.StringToPrivateKey(treasureToBury.DecryptTreasureEthKey())
+	privateKey, err := eth_gateway.StringToPrivateKey(treasureToBury.DecryptTreasureEthKey())
 	if err != nil {
 		oyster_utils.LogIfError(err, nil)
 		return
 	}
 
-	callMsg := services.OysterCallMsg{
-		From:       services.StringToAddress(treasureToBury.ETHAddr),
+	callMsg := eth_gateway.OysterCallMsg{
+		From:       eth_gateway.StringToAddress(treasureToBury.ETHAddr),
 		PrivateKey: *privateKey,
 	}
 
@@ -496,21 +497,21 @@ func buryPRL(treasureToBury models.Treasure) {
 }
 
 func waitForPRL(treasureToBury models.Treasure) {
-	waitForConfirmation(treasureToBury, treasureToBury.PRLTxHash, treasureToBury.PRLTxNonce, services.PRLTransfer)
+	waitForConfirmation(treasureToBury, treasureToBury.PRLTxHash, treasureToBury.PRLTxNonce, eth_gateway.PRLTransfer)
 }
 
 func waitForGas(treasureToBury models.Treasure) {
-	waitForConfirmation(treasureToBury, treasureToBury.GasTxHash, treasureToBury.GasTxNonce, services.EthTransfer)
+	waitForConfirmation(treasureToBury, treasureToBury.GasTxHash, treasureToBury.GasTxNonce, eth_gateway.EthTransfer)
 }
 
 func waitForBury(treasureToBury models.Treasure) {
-	waitForConfirmation(treasureToBury, treasureToBury.BuryTxHash, treasureToBury.BuryTxNonce, services.PRLBury)
+	waitForConfirmation(treasureToBury, treasureToBury.BuryTxHash, treasureToBury.BuryTxNonce, eth_gateway.PRLBury)
 }
 
 // TODO: get this to work and un-comment out the calls to waitForPRL, waitForGas, and waitForBury
-func waitForConfirmation(treasureToBury models.Treasure, txHash string, txNonce int64, txType services.TxType) {
+func waitForConfirmation(treasureToBury models.Treasure, txHash string, txNonce int64, txType eth_gateway.TxType) {
 
-	success := EthWrapper.WaitForConfirmation(services.StringToTxHash(txHash), SecondsDelayForETHPolling)
+	success := EthWrapper.WaitForConfirmation(eth_gateway.StringToTxHash(txHash), SecondsDelayForETHPolling)
 
 	// we passed the row by value, get it again in case it has changed
 	treasureRow := models.Treasure{}
@@ -535,18 +536,18 @@ func waitForConfirmation(treasureToBury models.Treasure, txHash string, txNonce 
 	}
 }
 
-func updateStatusSuccess(txType services.TxType, treasureRow models.Treasure) models.PRLStatus {
+func updateStatusSuccess(txType eth_gateway.TxType, treasureRow models.Treasure) models.PRLStatus {
 	var newStatus models.PRLStatus
 	switch txType {
-	case services.PRLTransfer:
+	case eth_gateway.PRLTransfer:
 		if treasureRow.PRLStatus == models.PRLPending || treasureRow.PRLStatus == models.PRLError {
 			newStatus = models.PRLConfirmed
 		}
-	case services.EthTransfer:
+	case eth_gateway.EthTransfer:
 		if treasureRow.PRLStatus == models.GasPending || treasureRow.PRLStatus == models.GasError {
 			newStatus = models.GasConfirmed
 		}
-	case services.PRLBury:
+	case eth_gateway.PRLBury:
 		if treasureRow.PRLStatus == models.BuryPending || treasureRow.PRLStatus == models.BuryError {
 			newStatus = models.BuryConfirmed
 		}
@@ -556,18 +557,18 @@ func updateStatusSuccess(txType services.TxType, treasureRow models.Treasure) mo
 	return newStatus
 }
 
-func updateStatusFailed(txType services.TxType, treasureRow models.Treasure) models.PRLStatus {
+func updateStatusFailed(txType eth_gateway.TxType, treasureRow models.Treasure) models.PRLStatus {
 	var newStatus models.PRLStatus
 	switch txType {
-	case services.PRLTransfer:
+	case eth_gateway.PRLTransfer:
 		if treasureRow.PRLStatus == models.PRLPending {
 			newStatus = models.PRLError
 		}
-	case services.EthTransfer:
+	case eth_gateway.EthTransfer:
 		if treasureRow.PRLStatus == models.GasPending {
 			newStatus = models.GasError
 		}
-	case services.PRLBury:
+	case eth_gateway.PRLBury:
 		if treasureRow.PRLStatus == models.BuryPending {
 			newStatus = models.BuryError
 		}
@@ -578,23 +579,23 @@ func updateStatusFailed(txType services.TxType, treasureRow models.Treasure) mod
 }
 
 // logInvalidTxType Utility to log txType errors and prlStatus
-func logInvalidTxType(txType services.TxType, status models.PRLStatus) {
+func logInvalidTxType(txType eth_gateway.TxType, status models.PRLStatus) {
 	txString := txToString(txType)
 	errorMsg := fmt.Sprintf("not a valid tx type (%v) in bury_treasure_addresses waitForConfirmation  status : %v", txString, status)
 	oyster_utils.LogIfError(errors.New(errorMsg), nil)
 }
 
 // txToString Utility to return the transaction type
-func txToString(value services.TxType) string {
+func txToString(value eth_gateway.TxType) string {
 	status := "Not Found"
 	switch value {
-	case services.PRLTransfer:
+	case eth_gateway.PRLTransfer:
 		status = "PRL Transfer"
-	case services.EthTransfer:
+	case eth_gateway.EthTransfer:
 		status = "Ether Transfer"
-	case services.PRLBury:
+	case eth_gateway.PRLBury:
 		status = "PRL Bury"
-	case services.PRLClaim:
+	case eth_gateway.PRLClaim:
 		status = "PRL Claim"
 	}
 	return status

--- a/jobs/check_alpha_payments_test.go
+++ b/jobs/check_alpha_payments_test.go
@@ -6,8 +6,8 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/oysterprotocol/brokernode/jobs"
 	"github.com/oysterprotocol/brokernode/models"
-	"github.com/oysterprotocol/brokernode/services"
 	"github.com/oysterprotocol/brokernode/utils"
+	"github.com/oysterprotocol/brokernode/utils/eth_gateway"
 	"github.com/shopspring/decimal"
 	"math/big"
 )
@@ -31,7 +31,7 @@ func resetTestVariables_checkAlphaPayments(suite *JobsSuite) {
 	hasCalledSendETH_checkAlphaPayments = false
 	hasCalledSendPRL_checkAlphaPayments = false
 
-	jobs.EthWrapper = services.EthWrapper
+	jobs.EthWrapper = eth_gateway.EthWrapper
 }
 
 func (suite *JobsSuite) Test_CheckPaymentToAlpha_no_prl_balance() {
@@ -294,13 +294,13 @@ func (suite *JobsSuite) Test_CheckGasPayments_gas_arrived() {
 
 func (suite *JobsSuite) Test_SendPaymentToBeta_payment_already_arrived() {
 	resetTestVariables_checkAlphaPayments(suite)
-	jobs.EthWrapper.CreateSendPRLMessage = services.EthWrapper.CreateSendPRLMessage
+	jobs.EthWrapper.CreateSendPRLMessage = eth_gateway.EthWrapper.CreateSendPRLMessage
 	jobs.EthWrapper.CheckPRLBalance = func(addr common.Address) *big.Int {
 		hasCalledCheckPRLBalance_checkAlphaPayments = true
 		// give a large balance so we will see the payment as already arrived
 		return big.NewInt(999999999999)
 	}
-	jobs.EthWrapper.SendPRLFromOyster = func(msg services.OysterCallMsg) (bool, string, int64) {
+	jobs.EthWrapper.SendPRLFromOyster = func(msg eth_gateway.OysterCallMsg) (bool, string, int64) {
 		hasCalledSendPRL_checkAlphaPayments = true
 		return true, "some__transaction_hash", 0
 	}
@@ -323,13 +323,13 @@ func (suite *JobsSuite) Test_SendPaymentToBeta_payment_already_arrived() {
 
 func (suite *JobsSuite) Test_SendPaymentToBeta_send_payment() {
 	resetTestVariables_checkAlphaPayments(suite)
-	jobs.EthWrapper.CreateSendPRLMessage = services.EthWrapper.CreateSendPRLMessage
+	jobs.EthWrapper.CreateSendPRLMessage = eth_gateway.EthWrapper.CreateSendPRLMessage
 	jobs.EthWrapper.CheckPRLBalance = func(addr common.Address) *big.Int {
 		hasCalledCheckPRLBalance_checkAlphaPayments = true
 		// give a 0 balance so we will send the PRL
 		return big.NewInt(0)
 	}
-	jobs.EthWrapper.SendPRLFromOyster = func(msg services.OysterCallMsg) (bool, string, int64) {
+	jobs.EthWrapper.SendPRLFromOyster = func(msg eth_gateway.OysterCallMsg) (bool, string, int64) {
 		hasCalledSendPRL_checkAlphaPayments = true
 		return true, "some__transaction_hash", 0
 	}

--- a/jobs/check_beta_payments.go
+++ b/jobs/check_beta_payments.go
@@ -5,6 +5,7 @@ import (
 	"github.com/oysterprotocol/brokernode/models"
 	"github.com/oysterprotocol/brokernode/services"
 	"github.com/oysterprotocol/brokernode/utils"
+	"github.com/oysterprotocol/brokernode/utils/eth_gateway"
 	"github.com/pkg/errors"
 	"gopkg.in/segmentio/analytics-go.v3"
 	"math/big"
@@ -33,7 +34,7 @@ func CheckPaymentToBeta() {
 		[]models.PaymentStatus{models.BrokerTxBetaPaymentPending})
 
 	for _, brokerTx := range brokerTxs {
-		balance := EthWrapper.CheckPRLBalance(services.StringToAddress(brokerTx.ETHAddrBeta))
+		balance := EthWrapper.CheckPRLBalance(eth_gateway.StringToAddress(brokerTx.ETHAddrBeta))
 		expectedBalance := new(big.Int).Quo(brokerTx.GetTotalCostInWei(), big.NewInt(int64(2)))
 		if balance.Int64() > 0 && balance.Int64() >= expectedBalance.Int64() {
 			previousBetaPaymentStatus := brokerTx.PaymentStatus

--- a/jobs/check_beta_payments_test.go
+++ b/jobs/check_beta_payments_test.go
@@ -4,8 +4,8 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/oysterprotocol/brokernode/jobs"
 	"github.com/oysterprotocol/brokernode/models"
-	"github.com/oysterprotocol/brokernode/services"
 	"github.com/oysterprotocol/brokernode/utils"
+	"github.com/oysterprotocol/brokernode/utils/eth_gateway"
 	"math/big"
 	"time"
 )
@@ -26,7 +26,7 @@ func resetTestVariables_checkBetaPayments(suite *JobsSuite) {
 	hasCalledCalculateGas_checkBetaPayments = false
 	hasCalledSendETH_checkBetaPayments = false
 
-	jobs.EthWrapper = services.EthWrapper
+	jobs.EthWrapper = eth_gateway.EthWrapper
 }
 
 func (suite *JobsSuite) Test_CheckPaymentToBeta_payment_arrived() {

--- a/jobs/claim_treasure_for_webnode_test.go
+++ b/jobs/claim_treasure_for_webnode_test.go
@@ -6,8 +6,8 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/oysterprotocol/brokernode/jobs"
 	"github.com/oysterprotocol/brokernode/models"
-	"github.com/oysterprotocol/brokernode/services"
 	"github.com/oysterprotocol/brokernode/utils"
+	"github.com/oysterprotocol/brokernode/utils/eth_gateway"
 	"github.com/pkg/errors"
 	"math/big"
 	"time"
@@ -40,7 +40,7 @@ func resetTestVariables_claimTreasureForWebnode(suite *JobsSuite) {
 	calculateGasNeededCalls_claimTreasureForWebnode = 0
 	chechPRLBalanceCalls_claimTreasureForWebnode = 0
 
-	jobs.EthWrapper = services.EthWrapper
+	jobs.EthWrapper = eth_gateway.EthWrapper
 }
 
 func (suite *JobsSuite) Test_CheckOngoingGasTransactions_gas_has_arrived() {
@@ -952,8 +952,8 @@ func generateWebnodeTreasureClaims(suite *JobsSuite,
 	numToGenerate int) {
 
 	for i := 0; i < numToGenerate; i++ {
-		treasureAddr, key, _ := services.EthWrapper.GenerateEthAddr()
-		receiverAddr, _, _ := services.EthWrapper.GenerateEthAddr()
+		treasureAddr, key, _ := eth_gateway.EthWrapper.GenerateEthAddr()
+		receiverAddr, _, _ := eth_gateway.EthWrapper.GenerateEthAddr()
 
 		validChars := []rune("abcde123456789")
 		genesisHash := oyster_utils.RandSeq(64, validChars)

--- a/jobs/claim_unused_prls.go
+++ b/jobs/claim_unused_prls.go
@@ -6,6 +6,7 @@ import (
 	"github.com/oysterprotocol/brokernode/models"
 	"github.com/oysterprotocol/brokernode/services"
 	"github.com/oysterprotocol/brokernode/utils"
+	"github.com/oysterprotocol/brokernode/utils/eth_gateway"
 	"gopkg.in/segmentio/analytics-go.v3"
 	"time"
 )
@@ -50,7 +51,7 @@ func CheckProcessingGasTransactions() {
 	}
 
 	for _, pending := range gasPending {
-		ethBalance := EthWrapper.CheckETHBalance(services.StringToAddress(pending.ETHAddr))
+		ethBalance := EthWrapper.CheckETHBalance(eth_gateway.StringToAddress(pending.ETHAddr))
 		if ethBalance.Int64() > 0 {
 			fmt.Println("ETH (gas) transaction sent to " + pending.ETHAddr + " in CheckProcessingGasTransactions() " +
 				"in claim_unused_prls")
@@ -81,7 +82,7 @@ func CheckProcessingPRLTransactions() {
 	}
 
 	for _, pending := range prlsPending {
-		prlBalance := EthWrapper.CheckPRLBalance(services.StringToAddress(pending.ETHAddr))
+		prlBalance := EthWrapper.CheckPRLBalance(eth_gateway.StringToAddress(pending.ETHAddr))
 		if prlBalance.Int64() == int64(0) {
 			fmt.Println("Unused PRLs retrieved from " + pending.ETHAddr + " in CheckProcessingPRLTransactions() " +
 				"in claim_unused_prls")
@@ -112,9 +113,9 @@ func CheckProcessingGasReclaims() {
 	}
 
 	for _, pending := range gasReclaimPending {
-		ethBalance := EthWrapper.CheckETHBalance(services.StringToAddress(pending.ETHAddr))
+		ethBalance := EthWrapper.CheckETHBalance(eth_gateway.StringToAddress(pending.ETHAddr))
 		if ethBalance.Int64() > 0 {
-			gasNeededToReclaimETH, err := EthWrapper.CalculateGasNeeded(services.GasLimitETHSend)
+			gasNeededToReclaimETH, err := EthWrapper.CalculateGasNeeded(eth_gateway.GasLimitETHSend)
 			if err != nil {
 				fmt.Println("Could not calculate gas needed to retrieve ETH from " + pending.ETHAddr +
 					" in CheckProcessingGasReclaims() in claim_unused_prls")
@@ -235,7 +236,7 @@ func SendGasForNewClaims() {
 	}
 	needGasHavePRLs := []models.CompletedUpload{}
 	for _, completedUpload := range needGas {
-		balance := EthWrapper.CheckPRLBalance(services.StringToAddress(completedUpload.ETHAddr))
+		balance := EthWrapper.CheckPRLBalance(eth_gateway.StringToAddress(completedUpload.ETHAddr))
 
 		if balance.Int64() == 0 {
 			fmt.Println("No balance at address " + completedUpload.ETHAddr)
@@ -289,7 +290,7 @@ func RetrieveLeftoverETH(thresholdTime time.Time) {
 	}
 	for _, completedClaim := range completedClaims {
 		worthReclaimingGas, gasToReclaim, err := EthWrapper.CheckIfWorthReclaimingGas(
-			services.StringToAddress(completedClaim.ETHAddr), services.GasLimitETHSend)
+			eth_gateway.StringToAddress(completedClaim.ETHAddr), eth_gateway.GasLimitETHSend)
 		if err != nil {
 			fmt.Println("Error determining if it's worth it to retrieve leftover ETH from " +
 				completedClaim.ETHAddr +
@@ -314,9 +315,9 @@ func RetrieveLeftoverETH(thresholdTime time.Time) {
 			continue
 		}
 
-		privateKey, err := services.StringToPrivateKey(completedClaim.DecryptSessionEthKey())
+		privateKey, err := eth_gateway.StringToPrivateKey(completedClaim.DecryptSessionEthKey())
 
-		reclaimingSuccess := EthWrapper.ReclaimGas(services.StringToAddress(completedClaim.ETHAddr),
+		reclaimingSuccess := EthWrapper.ReclaimGas(eth_gateway.StringToAddress(completedClaim.ETHAddr),
 			privateKey, gasToReclaim)
 
 		if reclaimingSuccess {
@@ -330,16 +331,16 @@ func RetrieveLeftoverETH(thresholdTime time.Time) {
 
 // wraps call to eth_gatway's SendETH method and sets GasStatus to GasTransferProcessing
 func InitiateGasTransfer(uploadsThatNeedGas []models.CompletedUpload) {
-	gasToSend, err := EthWrapper.CalculateGasNeeded(services.GasLimitPRLSend)
+	gasToSend, err := EthWrapper.CalculateGasNeeded(eth_gateway.GasLimitPRLSend)
 	if err != nil {
 		oyster_utils.LogIfError(fmt.Errorf("Error determining gas to send: %v", err), nil)
 		return
 	}
 	for _, upload := range uploadsThatNeedGas {
 		_, txHash, nonce, err := EthWrapper.SendETH(
-			services.MainWalletAddress,
-			services.MainWalletPrivateKey,
-			services.StringToAddress(upload.ETHAddr),
+			eth_gateway.MainWalletAddress,
+			eth_gateway.MainWalletPrivateKey,
+			eth_gateway.StringToAddress(upload.ETHAddr),
 			gasToSend)
 		if err != nil {
 			oyster_utils.LogIfError(err, nil)
@@ -356,7 +357,7 @@ func InitiateGasTransfer(uploadsThatNeedGas []models.CompletedUpload) {
 // wraps calls eth_gatway's SendPRLFromOyster method and sets PRLStatus to PRLClaimProcessing
 func InitiatePRLClaim(uploadsWithUnclaimedPRLs []models.CompletedUpload) {
 	for _, upload := range uploadsWithUnclaimedPRLs {
-		balance := EthWrapper.CheckPRLBalance(services.StringToAddress(upload.ETHAddr))
+		balance := EthWrapper.CheckPRLBalance(eth_gateway.StringToAddress(upload.ETHAddr))
 		if balance.Int64() == -1 {
 			fmt.Println("Error getting balance of address " + upload.ETHAddr)
 			continue
@@ -364,14 +365,14 @@ func InitiatePRLClaim(uploadsWithUnclaimedPRLs []models.CompletedUpload) {
 
 		privateKey := upload.DecryptSessionEthKey()
 
-		ecdsaPrivateKey, err := services.StringToPrivateKey(privateKey)
+		ecdsaPrivateKey, err := eth_gateway.StringToPrivateKey(privateKey)
 
 		if err != nil {
 			oyster_utils.LogIfError(err, nil)
 			continue
 		}
-		callMsg, err := EthWrapper.CreateSendPRLMessage(services.StringToAddress(upload.ETHAddr),
-			ecdsaPrivateKey, services.MainWalletAddress, *balance)
+		callMsg, err := EthWrapper.CreateSendPRLMessage(eth_gateway.StringToAddress(upload.ETHAddr),
+			ecdsaPrivateKey, eth_gateway.MainWalletAddress, *balance)
 
 		if err != nil {
 			oyster_utils.LogIfError(err, nil)

--- a/jobs/claim_unused_prls_test.go
+++ b/jobs/claim_unused_prls_test.go
@@ -6,8 +6,8 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/oysterprotocol/brokernode/jobs"
 	"github.com/oysterprotocol/brokernode/models"
-	"github.com/oysterprotocol/brokernode/services"
 	"github.com/oysterprotocol/brokernode/utils"
+	"github.com/oysterprotocol/brokernode/utils/eth_gateway"
 	"math/big"
 	"time"
 )
@@ -593,9 +593,9 @@ func resetTestVariables() {
 	hasCalledReclaimGas = false
 	hasCalledCheckIfWorthReclaimingGas = false
 
-	jobs.EthWrapper = services.Eth{
-		GenerateEthAddr:      services.EthWrapper.GenerateEthAddr,
-		CreateSendPRLMessage: services.EthWrapper.CreateSendPRLMessage,
+	jobs.EthWrapper = eth_gateway.Eth{
+		GenerateEthAddr:      eth_gateway.EthWrapper.GenerateEthAddr,
+		CreateSendPRLMessage: eth_gateway.EthWrapper.CreateSendPRLMessage,
 		CheckPRLBalance: func(addr common.Address) *big.Int {
 			hasCalledCheckPRLBalance = true
 			return big.NewInt(600000000000000000)
@@ -604,7 +604,7 @@ func resetTestVariables() {
 			hasCalledCheckETHBalance = true
 			return big.NewInt(600000000000000000)
 		},
-		SendPRLFromOyster: func(msg services.OysterCallMsg) (bool, string, int64) {
+		SendPRLFromOyster: func(msg eth_gateway.OysterCallMsg) (bool, string, int64) {
 			SentToSendPRLFromOyster++
 			hasCalledSendPRLFromOyster = true
 			return false, "some__transaction_hash", 0

--- a/jobs/job_runner.go
+++ b/jobs/job_runner.go
@@ -1,6 +1,7 @@
 package jobs
 
 import (
+	"github.com/oysterprotocol/brokernode/utils/eth_gateway"
 	"os"
 	"reflect"
 	"runtime"
@@ -24,7 +25,7 @@ var OysterWorker = worker.NewSimple()
 
 var (
 	IotaWrapper       = services.IotaWrapper
-	EthWrapper        = services.EthWrapper
+	EthWrapper        = eth_gateway.EthWrapper
 	PrometheusWrapper = services.PrometheusWrapper
 )
 

--- a/jobs/job_runner_test.go
+++ b/jobs/job_runner_test.go
@@ -1,6 +1,7 @@
 package jobs_test
 
 import (
+	"github.com/oysterprotocol/brokernode/utils/eth_gateway"
 	"strconv"
 	"testing"
 
@@ -27,7 +28,7 @@ func (suite *JobsSuite) SetupTest() {
 	// Reset the jobs's IotaWrapper, EthWrapper before each test.
 	// Some tests may override this value.
 	jobs.IotaWrapper = services.IotaWrapper
-	jobs.EthWrapper = services.EthWrapper
+	jobs.EthWrapper = eth_gateway.EthWrapper
 	jobs.PrometheusWrapper = services.PrometheusWrapper
 
 	/*

--- a/jobs/remove_unpaid_upload_session.go
+++ b/jobs/remove_unpaid_upload_session.go
@@ -6,6 +6,7 @@ import (
 	"github.com/oysterprotocol/brokernode/models"
 	"github.com/oysterprotocol/brokernode/services"
 	"github.com/oysterprotocol/brokernode/utils"
+	"github.com/oysterprotocol/brokernode/utils/eth_gateway"
 )
 
 /*UnpaidExpirationInHour means number of hours before it should remove unpaid upload session. */
@@ -28,7 +29,7 @@ func RemoveUnpaidUploadSession(PrometheusWrapper services.PrometheusService) {
 	}
 
 	for _, session := range sessions {
-		balance := EthWrapper.CheckPRLBalance(services.StringToAddress(session.ETHAddrAlpha.String))
+		balance := EthWrapper.CheckPRLBalance(eth_gateway.StringToAddress(session.ETHAddrAlpha.String))
 		if balance.Int64() > 0 {
 			continue
 		}

--- a/jobs/remove_unpaid_upload_session_test.go
+++ b/jobs/remove_unpaid_upload_session_test.go
@@ -1,13 +1,13 @@
 package jobs_test
 
 import (
+	"github.com/oysterprotocol/brokernode/utils/eth_gateway"
 	"math/big"
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/oysterprotocol/brokernode/jobs"
 	"github.com/oysterprotocol/brokernode/models"
-	"github.com/oysterprotocol/brokernode/services"
 	"github.com/oysterprotocol/brokernode/utils"
 )
 
@@ -20,7 +20,7 @@ func (suite *JobsSuite) Test_RemoveUnpaid_uploadSessionsAndDataMap_badger() {
 	oyster_utils.SetBrokerMode(oyster_utils.ProdMode)
 	defer oyster_utils.ResetBrokerMode()
 
-	jobs.EthWrapper = services.Eth{
+	jobs.EthWrapper = eth_gateway.Eth{
 		CheckPRLBalance: func(addr common.Address) *big.Int {
 			return big.NewInt(0)
 		},
@@ -58,7 +58,7 @@ func (suite *JobsSuite) Test_RemoveUnpaid_hasBalance_badger() {
 
 	removeAllUploadSessions(suite)
 
-	jobs.EthWrapper = services.Eth{
+	jobs.EthWrapper = eth_gateway.Eth{
 		CheckPRLBalance: func(addr common.Address) *big.Int {
 			return big.NewInt(10)
 		},
@@ -77,7 +77,7 @@ func (suite *JobsSuite) Test_RemoveUnpaid_OnlyRemoveUploadSession_badger() {
 
 	removeAllUploadSessions(suite)
 
-	jobs.EthWrapper = services.Eth{
+	jobs.EthWrapper = eth_gateway.Eth{
 		CheckPRLBalance: func(addr common.Address) *big.Int {
 			return big.NewInt(0)
 		},
@@ -102,7 +102,7 @@ func (suite *JobsSuite) Test_RemoveUnpaid_uploadSessionsAndDataMap_sql() {
 	oyster_utils.SetBrokerMode(oyster_utils.ProdMode)
 	defer oyster_utils.ResetBrokerMode()
 
-	jobs.EthWrapper = services.Eth{
+	jobs.EthWrapper = eth_gateway.Eth{
 		CheckPRLBalance: func(addr common.Address) *big.Int {
 			return big.NewInt(0)
 		},
@@ -139,7 +139,7 @@ func (suite *JobsSuite) Test_RemoveUnpaid_hasBalance_sql() {
 
 	removeAllUploadSessions(suite)
 
-	jobs.EthWrapper = services.Eth{
+	jobs.EthWrapper = eth_gateway.Eth{
 		CheckPRLBalance: func(addr common.Address) *big.Int {
 			return big.NewInt(10)
 		},
@@ -158,7 +158,7 @@ func (suite *JobsSuite) Test_RemoveUnpaid_OnlyRemoveUploadSession_sql() {
 
 	removeAllUploadSessions(suite)
 
-	jobs.EthWrapper = services.Eth{
+	jobs.EthWrapper = eth_gateway.Eth{
 		CheckPRLBalance: func(addr common.Address) *big.Int {
 			return big.NewInt(0)
 		},

--- a/models/treasure_test.go
+++ b/models/treasure_test.go
@@ -3,8 +3,8 @@ package models_test
 import (
 	"encoding/hex"
 	"github.com/oysterprotocol/brokernode/models"
-	"github.com/oysterprotocol/brokernode/services"
 	"github.com/oysterprotocol/brokernode/utils"
+	"github.com/oysterprotocol/brokernode/utils/eth_gateway"
 	"math/big"
 	"time"
 )
@@ -52,7 +52,7 @@ func (suite *ModelSuite) Test_Get_And_Set_PRL_Amount() {
 
 	prlAmount := big.NewInt(5000000000000000000)
 
-	ethAddr, key, _ := services.EthWrapper.GenerateEthAddr()
+	ethAddr, key, _ := eth_gateway.EthWrapper.GenerateEthAddr()
 	iotaAddr := oyster_utils.RandSeq(81, oyster_utils.TrytesAlphabet)
 	iotaMessage := oyster_utils.RandSeq(10, oyster_utils.TrytesAlphabet)
 
@@ -72,7 +72,7 @@ func (suite *ModelSuite) Test_Get_And_Set_PRL_Amount() {
 func (suite *ModelSuite) Test_EncryptAndDecryptEthPrivateKey() {
 
 	ethKey := hex.EncodeToString([]byte("SOME_PRIVATE_KEY"))
-	ethAddr, _, _ := services.EthWrapper.GenerateEthAddr()
+	ethAddr, _, _ := eth_gateway.EthWrapper.GenerateEthAddr()
 	iotaAddr := oyster_utils.RandSeq(81, oyster_utils.TrytesAlphabet)
 	iotaMessage := oyster_utils.RandSeq(10, oyster_utils.TrytesAlphabet)
 
@@ -112,7 +112,7 @@ func generateTreasuresToBuryOfEachStatus(suite *ModelSuite, numToCreateOfEachSta
 func generateTreasuresToBury(suite *ModelSuite, numToCreateOfEachStatus int, status models.PRLStatus) {
 	prlAmount := big.NewInt(500000000000000000)
 	for i := 0; i < numToCreateOfEachStatus; i++ {
-		ethAddr, key, _ := services.EthWrapper.GenerateEthAddr()
+		ethAddr, key, _ := eth_gateway.EthWrapper.GenerateEthAddr()
 		iotaAddr := oyster_utils.RandSeq(81, oyster_utils.TrytesAlphabet)
 		iotaMessage := oyster_utils.RandSeq(10, oyster_utils.TrytesAlphabet)
 

--- a/models/webnode_treasure_claims_test.go
+++ b/models/webnode_treasure_claims_test.go
@@ -2,8 +2,8 @@ package models_test
 
 import (
 	"github.com/oysterprotocol/brokernode/models"
-	"github.com/oysterprotocol/brokernode/services"
 	"github.com/oysterprotocol/brokernode/utils"
+	"github.com/oysterprotocol/brokernode/utils/eth_gateway"
 	"time"
 )
 
@@ -187,8 +187,8 @@ func generateWebnodeTreasureClaims(ms *ModelSuite,
 	numToGenerate int) {
 
 	for i := 0; i < numToGenerate; i++ {
-		treasureAddr, key, _ := services.EthWrapper.GenerateEthAddr()
-		receiverAddr, _, _ := services.EthWrapper.GenerateEthAddr()
+		treasureAddr, key, _ := eth_gateway.EthWrapper.GenerateEthAddr()
+		receiverAddr, _, _ := eth_gateway.EthWrapper.GenerateEthAddr()
 
 		validChars := []rune("abcde123456789")
 		genesisHash := oyster_utils.RandSeq(64, validChars)

--- a/utils/eth_gateway/eth_gateway.go
+++ b/utils/eth_gateway/eth_gateway.go
@@ -1,4 +1,4 @@
-package services
+package eth_gateway
 
 import (
 	"context"

--- a/utils/eth_gateway/eth_gateway_mock.go
+++ b/utils/eth_gateway/eth_gateway_mock.go
@@ -1,4 +1,4 @@
-package services
+package eth_gateway
 
 var EthMock Eth
 

--- a/utils/eth_gateway/eth_gateway_test.go
+++ b/utils/eth_gateway/eth_gateway_test.go
@@ -1,4 +1,4 @@
-package services_test
+package eth_gateway_test
 
 import (
 	"context"
@@ -20,7 +20,7 @@ import (
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/ethereum/go-ethereum/params"
-	"github.com/oysterprotocol/brokernode/services"
+	"github.com/oysterprotocol/brokernode/utils/eth_gateway"
 )
 
 //
@@ -106,7 +106,7 @@ func printTx(tx *types.Transaction) {
 // generate address test
 func test_generateAddress(t *testing.T) {
 	// generate eth address using gateway
-	addr, privateKey, err := services.EthWrapper.GenerateEthAddr()
+	addr, privateKey, err := eth_gateway.EthWrapper.GenerateEthAddr()
 	if err != nil {
 		t.Fatalf("error creating ethereum network address")
 	}
@@ -126,12 +126,12 @@ func test_generateAddress(t *testing.T) {
 func test_generateEthAddrFromPrivateKey(t *testing.T) {
 	//services.RunOnTestNet()
 	// generate eth address using gateway
-	originalAddr, originalPrivateKey, err := services.EthWrapper.GenerateEthAddr()
+	originalAddr, originalPrivateKey, err := eth_gateway.EthWrapper.GenerateEthAddr()
 	if err != nil {
 		t.Fatalf("error creating ethereum network address")
 	}
 
-	generatedAddress := services.EthWrapper.GenerateEthAddrFromPrivateKey(originalPrivateKey)
+	generatedAddress := eth_gateway.EthWrapper.GenerateEthAddrFromPrivateKey(originalPrivateKey)
 
 	// ensure address is what we expected
 	if originalAddr != generatedAddress {
@@ -145,7 +145,7 @@ func test_getGasPrice(t *testing.T) {
 	//services.RunOnTestNet()
 	t.Skip(nil)
 	// get the suggested gas price
-	gasPrice, err := services.EthWrapper.GetGasPrice()
+	gasPrice, err := eth_gateway.EthWrapper.GetGasPrice()
 	if err != nil {
 		t.Fatalf("error retrieving gas price: %v\n", err)
 	}
@@ -159,7 +159,7 @@ func test_getGasPrice(t *testing.T) {
 
 // check if it's worth it to try and reclaiming eth from an address
 func test_checkIfWorthReclaimingGas(t *testing.T) {
-	worthIt, amountToReclaim, err := services.EthWrapper.CheckIfWorthReclaimingGas(ethAddress01, services.GasLimitETHSend)
+	worthIt, amountToReclaim, err := eth_gateway.EthWrapper.CheckIfWorthReclaimingGas(ethAddress01, eth_gateway.GasLimitETHSend)
 
 	if worthIt {
 		t.Logf("Should try to reclaim gas: %v\n", "true")
@@ -180,7 +180,7 @@ func test_reclaimGas(t *testing.T) {
 	gasToReclaim := big.NewInt(5000)
 	prlWallet := getWallet(prl2File)
 
-	success := services.EthWrapper.ReclaimGas(prlWallet.Address, prlWallet.PrivateKey, gasToReclaim)
+	success := eth_gateway.EthWrapper.ReclaimGas(prlWallet.Address, prlWallet.PrivateKey, gasToReclaim)
 
 	// This isn't a very good test because it succeeds regardless of the outcome?
 
@@ -195,12 +195,12 @@ func test_reclaimGas(t *testing.T) {
 func test_calculateGasNeeded(t *testing.T) {
 	t.Skip(nil)
 
-	gasPrice, err := services.EthWrapper.GetGasPrice()
-	gasLimitToUse := services.GasLimitETHSend
+	gasPrice, err := eth_gateway.EthWrapper.GetGasPrice()
+	gasLimitToUse := eth_gateway.GasLimitETHSend
 
 	expectedGasToSend := new(big.Int).Mul(gasPrice, big.NewInt(int64(gasLimitToUse)))
 
-	gasToSend, err := services.EthWrapper.CalculateGasNeeded(gasLimitToUse)
+	gasToSend, err := eth_gateway.EthWrapper.CalculateGasNeeded(gasLimitToUse)
 	if expectedGasToSend.Int64() != gasToSend.Int64() {
 		t.Fatalf("failed to calculate the gas to send: %v\n", err)
 	}
@@ -217,7 +217,7 @@ func test_checkETHBalance(t *testing.T) {
 	//t.Skip(nil)
 	// test balance for an ether account
 	// Convert string address to byte[] address form
-	bal := services.EthWrapper.CheckETHBalance(ethAddress01)
+	bal := eth_gateway.EthWrapper.CheckETHBalance(ethAddress01)
 	if bal.Int64() != -1 {
 		t.Logf("balance verified: %v\n", bal)
 	} else {
@@ -228,7 +228,7 @@ func test_checkETHBalance(t *testing.T) {
 // get current block number
 func test_getCurrentBlockNumber(t *testing.T) {
 	// Get the current block from the network
-	block, err := services.EthWrapper.GetCurrentBlock()
+	block, err := eth_gateway.EthWrapper.GetCurrentBlock()
 	if err != nil {
 		t.Fatalf("could not retrieve the current block: %v\n", err)
 	}
@@ -242,7 +242,7 @@ func test_getCurrentBlockGasLimit(t *testing.T) {
 	//t.Skip(nil)
 	//services.RunOnTestNet()
 	// Get the current block from the network
-	block, err := services.EthWrapper.GetCurrentBlock()
+	block, err := eth_gateway.EthWrapper.GetCurrentBlock()
 	if err != nil {
 		t.Fatalf("could not retrieve the current block: %v\n", err)
 	}
@@ -256,7 +256,7 @@ func test_getNonceForAccount(t *testing.T) {
 	// TODO:  works remove Skip()
 	//t.Skip(nil)
 	// Get the nonce for the given account
-	nonce, err := services.EthWrapper.GetNonce(context.Background(), ethCoinbase)
+	nonce, err := eth_gateway.EthWrapper.GetNonce(context.Background(), ethCoinbase)
 	if err != nil {
 		t.Fatalf("unable to access the account nonce : %v", err)
 	} else {
@@ -267,12 +267,12 @@ func test_getNonceForAccount(t *testing.T) {
 // send gas(ether) to an address for a transaction
 func test_sendEth(t *testing.T) {
 	t.Skip(nil)
-	services.RunOnTestNet()
+	eth_gateway.RunOnTestNet()
 	// transfer
 	transferValue := big.NewInt(1)
 	transferValueInWei := new(big.Int).Mul(transferValue, oneWei)
 	// Send ether to test account
-	txs, _, _, err := services.EthWrapper.SendETH(services.MainWalletAddress, services.MainWalletPrivateKey, ethAddress02, transferValueInWei)
+	txs, _, _, err := eth_gateway.EthWrapper.SendETH(eth_gateway.MainWalletAddress, eth_gateway.MainWalletPrivateKey, ethAddress02, transferValueInWei)
 	if err != nil {
 		t.Logf("failed to send ether to %v ether to %v\n", transferValue, ethAddress02.Hex())
 		t.Fatalf("transaction error: %v\n", err)
@@ -284,7 +284,7 @@ func test_sendEth(t *testing.T) {
 		printTx(transaction)
 
 		// wait for confirmation
-		confirmed := services.EthWrapper.WaitForConfirmation(lastTransaction.Hash(), 3)
+		confirmed := eth_gateway.EthWrapper.WaitForConfirmation(lastTransaction.Hash(), 3)
 		if confirmed == 1 {
 			t.Logf("confirmed ether was sent to : %v", ethAddress02.Hex())
 		} else if confirmed == 0 {
@@ -302,10 +302,10 @@ func test_ensureTransactionStoredInPool(t *testing.T) {
 		txHash = lastTransactionHash
 	}
 	// check pending
-	isPending := services.EthWrapper.PendingConfirmation(txHash)
+	isPending := eth_gateway.EthWrapper.PendingConfirmation(txHash)
 	if isPending {
 		// get item by txHash and ensure its in the table
-		txWithBlockNumber := services.EthWrapper.GetTransaction(txHash)
+		txWithBlockNumber := eth_gateway.EthWrapper.GetTransaction(txHash)
 		if txWithBlockNumber.Transaction != nil {
 			// compare transaction hash
 			if reflect.DeepEqual(txWithBlockNumber.Transaction.Hash(), txHash) {
@@ -327,16 +327,16 @@ func test_confirmTransactionStatus(t *testing.T) {
 		txHash = lastTransactionHash
 	}
 	// check pending
-	isPending := services.EthWrapper.PendingConfirmation(txHash)
+	isPending := eth_gateway.EthWrapper.PendingConfirmation(txHash)
 	if isPending {
 		// check confirmation
-		txStatus := services.EthWrapper.WaitForConfirmation(txHash, 3)
+		txStatus := eth_gateway.EthWrapper.WaitForConfirmation(txHash, 3)
 		if txStatus == 0 {
 			t.Logf("transaction failure")
 		} else if txStatus == 1 {
 			t.Logf("confirmation completed")
 
-			bal := services.EthWrapper.CheckETHBalance(ethAddress02)
+			bal := eth_gateway.EthWrapper.CheckETHBalance(ethAddress02)
 			t.Logf("balance updated : %v", bal)
 		}
 	}
@@ -360,7 +360,7 @@ func test_deployOysterPearl(t *testing.T) {
 	defer cancel()
 
 	// deploy a token contract on the simulated blockchain
-	_, _, token, err := services.DeployOysterPearl(&bind.TransactOpts{
+	_, _, token, err := eth_gateway.DeployOysterPearl(&bind.TransactOpts{
 		Nonce:    big.NewInt(0),
 		From:     auth.From,
 		GasLimit: params.GenesisGasLimit,
@@ -398,7 +398,7 @@ func test_simOysterPearlBury(t *testing.T) {
 	//
 	// deploy a token contract on the simulated blockchain
 	//
-	_, _, token, err := services.DeployOysterPearl(&bind.TransactOpts{
+	_, _, token, err := eth_gateway.DeployOysterPearl(&bind.TransactOpts{
 		Nonce:    big.NewInt(0),
 		From:     auth.From,
 		GasLimit: params.GenesisGasLimit,
@@ -466,7 +466,7 @@ func test_tokenNameFromOysterPearl(t *testing.T) {
 	t.Skip(nil)
 	// test ethClient
 	var backend, _ = ethclient.Dial(oysterbyNetwork)
-	oysterPearl, err := services.NewOysterPearl(oysterContract, backend)
+	oysterPearl, err := eth_gateway.NewOysterPearl(oysterContract, backend)
 	if err != nil {
 		t.Fatalf("unable to access contract instance at :%v", err)
 	}
@@ -485,18 +485,18 @@ func test_stakePRLFromOysterPearl(t *testing.T) {
 	// test ethClient
 	var backend, _ = ethclient.Dial(oysterbyNetwork)
 	// instance of the oyster pearl contract
-	pearlDistribute, err := services.NewPearlDistributeOysterby(prlDistribution, backend)
+	pearlDistribute, err := eth_gateway.NewPearlDistributeOysterby(prlDistribution, backend)
 
 	// authentication
-	walletAddress := services.MainWalletAddress
+	walletAddress := eth_gateway.MainWalletAddress
 
 	t.Logf("using wallet key store from: %v\n", walletAddress.Hex())
 
-	gasPrice, _ := services.EthWrapper.GetGasPrice()
-	block, _ := services.EthWrapper.GetCurrentBlock()
+	gasPrice, _ := eth_gateway.EthWrapper.GetGasPrice()
+	block, _ := eth_gateway.EthWrapper.GetCurrentBlock()
 
 	// Create an authorized transactor and spend 1 PRL
-	auth := bind.NewKeyedTransactor(services.MainWalletPrivateKey)
+	auth := bind.NewKeyedTransactor(eth_gateway.MainWalletPrivateKey)
 	if err != nil {
 		t.Fatalf("unable to create a new transactor : %v", err)
 	}
@@ -537,7 +537,7 @@ func test_transferPRLFromOysterPearl(t *testing.T) {
 
 	prlValue := big.NewInt(0).SetUint64(toWei(15))
 	// sendPRL
-	sent, _, _ := services.EthWrapper.SendPRLFromOyster(services.OysterCallMsg{
+	sent, _, _ := eth_gateway.EthWrapper.SendPRLFromOyster(eth_gateway.OysterCallMsg{
 		Amount: *prlValue,
 	})
 
@@ -563,7 +563,7 @@ func test_sendPRL(t *testing.T) {
 	prlValue := big.NewInt(5)
 
 	// Compose OysterCall Message
-	var sendMsg = services.OysterCallMsg{
+	var sendMsg = eth_gateway.OysterCallMsg{
 		From:       prlWallet.Address,
 		To:         prlAddress02,
 		Amount:     *prlValue,
@@ -573,7 +573,7 @@ func test_sendPRL(t *testing.T) {
 
 	// Send PRL is a blocking call which will send the new transaction to the network
 	// then wait for the confirmation to return true or false
-	var confirmed = services.EthWrapper.SendPRL(sendMsg)
+	var confirmed = eth_gateway.EthWrapper.SendPRL(sendMsg)
 	if confirmed {
 		// successful prl send
 		t.Logf("Sent PRL to :%v", sendMsg.To.Hex())
@@ -597,7 +597,7 @@ func test_claimPRL(t *testing.T) {
 	treasurePrivateKey := prlWallet.PrivateKey
 
 	// Claim PRL
-	claimed := services.EthWrapper.ClaimPRL(receiverAddress, treasureAddress, treasurePrivateKey)
+	claimed := eth_gateway.EthWrapper.ClaimPRL(receiverAddress, treasureAddress, treasurePrivateKey)
 	if !claimed {
 		t.Fatal("Failed to claim PRLs")
 	} else {
@@ -619,7 +619,7 @@ func test_claimPRLInsufficientFunds(t *testing.T) {
 	treasurePrivateKey := prlWallet.PrivateKey
 
 	// Claim PRL
-	claimed := services.EthWrapper.ClaimPRL(receiverAddress, treasureAddress, treasurePrivateKey)
+	claimed := eth_gateway.EthWrapper.ClaimPRL(receiverAddress, treasureAddress, treasurePrivateKey)
 	if !claimed {
 		t.Log("Failed to claim PRLs") // expected result
 	} else {
@@ -635,13 +635,13 @@ func test_buryPRL(t *testing.T) {
 
 	prlValue := big.NewInt(1)
 	// only configure to and amount
-	buryMsg := services.OysterCallMsg{
+	buryMsg := eth_gateway.OysterCallMsg{
 		To:     prlAddress02,
 		Amount: *prlValue,
 	}
 
 	// Bury PRL
-	buried, _, _ := services.EthWrapper.BuryPrl(buryMsg)
+	buried, _, _ := eth_gateway.EthWrapper.BuryPrl(buryMsg)
 	if buried {
 		// successful bury attempt
 		t.Log("Buried the PRLs successfully")
@@ -654,9 +654,9 @@ func test_buryPRL(t *testing.T) {
 // check if an address is in a buried state
 func test_checkBuriedState(t *testing.T) {
 
-	addr, _, _ := services.EthWrapper.GenerateEthAddr()
+	addr, _, _ := eth_gateway.EthWrapper.GenerateEthAddr()
 
-	buried, err := services.EthWrapper.CheckBuriedState(addr)
+	buried, err := eth_gateway.EthWrapper.CheckBuriedState(addr)
 
 	if err != nil {
 		t.Fatal("Failed to check the bury state of the given address.")
@@ -672,9 +672,9 @@ func test_checkBuriedState(t *testing.T) {
 // check the claim clock value of an address
 func test_checkClaimClock(t *testing.T) {
 
-	addr, _, _ := services.EthWrapper.GenerateEthAddr()
+	addr, _, _ := eth_gateway.EthWrapper.GenerateEthAddr()
 
-	claimClock, err := services.EthWrapper.CheckClaimClock(addr)
+	claimClock, err := eth_gateway.EthWrapper.CheckClaimClock(addr)
 
 	if err != nil {
 		t.Fatal("Failed to check the claim of the given address.")
@@ -687,7 +687,7 @@ func test_checkClaimClock(t *testing.T) {
 func test_balanceOfFromOysterPearl(t *testing.T) {
 
 	// working pulls the balance from Oyster PRL on test net prl balances
-	bankBalance := services.EthWrapper.CheckPRLBalance(prlBankAddress)
+	bankBalance := eth_gateway.EthWrapper.CheckPRLBalance(prlBankAddress)
 	t.Logf("oyster pearl bank address balance :%v", bankBalance)
 
 }

--- a/utils/eth_gateway/oysterpearl.go
+++ b/utils/eth_gateway/oysterpearl.go
@@ -1,7 +1,7 @@
 // Code generated - DO NOT EDIT.
 // This file is a generated binding and any manual changes will be lost.
 
-package services
+package eth_gateway
 
 import (
 	"math/big"

--- a/utils/eth_gateway/pearlDistribute.go
+++ b/utils/eth_gateway/pearlDistribute.go
@@ -1,7 +1,7 @@
 // Code generated - DO NOT EDIT.
 // This file is a generated binding and any manual changes will be lost.
 
-package services
+package eth_gateway
 
 import (
 	"math/big"


### PR DESCRIPTION
As part of the backend rev2 changes, I'm going to need to pull eth_gateway out of services.  This is because I'll need to import something from services into models, but services already imports models, so that won't work.  

The backend rev2 changes are getting pretty large so I'm going to try to break them into smaller pieces if possible.  This is one of the PRs for that.  