### PR TITLE
Add attach_treasure job, add methods to treasures.go, update bury_treasure_addresses

### DIFF
--- a/jobs/attach_treasure.go
+++ b/jobs/attach_treasure.go
@@ -1,0 +1,122 @@
+package jobs
+
+import (
+	"github.com/gobuffalo/validate"
+	"github.com/oysterprotocol/brokernode/models"
+	"github.com/oysterprotocol/brokernode/services"
+	"github.com/oysterprotocol/brokernode/utils"
+	"gopkg.in/segmentio/analytics-go.v3"
+	"time"
+)
+
+func AttachTreasuresToTangle(iotaWrapper services.IotaService, PrometheusWrapper services.PrometheusService,
+	thresholdTime time.Time) {
+
+	start := PrometheusWrapper.TimeNow()
+	defer PrometheusWrapper.HistogramSeconds(PrometheusWrapper.HistogramAttachTreasuresToTangle, start)
+
+	AttachTreasureTransactions(iotaWrapper)
+	VerifyTreasureTransactions(iotaWrapper, thresholdTime)
+}
+
+func AttachTreasureTransactions(iotaWrapper services.IotaService) {
+	var vErr *validate.Errors
+	treasuresToAttach, err := models.GetTreasuresToBuryBySignedStatus([]models.SignedStatus{models.TreasureSigned,
+		models.TreasureAttachError})
+	if err != nil {
+		oyster_utils.LogIfError(err, nil)
+		return
+	}
+
+	for _, treasure := range treasuresToAttach {
+		chunk := oyster_utils.ChunkData{
+			Address:     treasure.Address,
+			Message:     treasure.Message,
+			GenesisHash: treasure.GenesisHash,
+			Idx:         treasure.Idx,
+		}
+
+		err := iotaWrapper.DoPoW([]oyster_utils.ChunkData{chunk})
+		var newStatus models.SignedStatus
+		displayString := "SUCCESS"
+		if err == nil {
+			newStatus = models.TreasureSignedAndAttached
+		} else {
+			displayString = "ERROR"
+			newStatus = models.TreasureAttachError
+		}
+		treasure.SignedStatus = newStatus
+		vErr, err = models.DB.ValidateAndUpdate(&treasure)
+		oyster_utils.LogIfValidationError("error updating treasure's SignedStatus to "+
+			models.SignedStatusMap[newStatus]+" in attach_treasure", vErr, nil)
+		oyster_utils.LogIfError(err, nil)
+		if err != nil || vErr.HasAny() {
+			displayString = "ERROR"
+		}
+		logTreasureAttachmentResult("attach_treasure attempted: "+displayString, treasure)
+	}
+}
+
+func VerifyTreasureTransactions(iotaWrapper services.IotaService, thresholdTime time.Time) {
+	treasuresToAttach, err := models.GetTreasuresToBuryBySignedStatus([]models.SignedStatus{
+		models.TreasureSignedAndAttached})
+	if err != nil {
+		oyster_utils.LogIfError(err, nil)
+		return
+	}
+
+	for _, treasure := range treasuresToAttach {
+		chunk := oyster_utils.ChunkData{
+			Address:     treasure.Address,
+			Message:     treasure.Message,
+			GenesisHash: treasure.GenesisHash,
+			Idx:         treasure.Idx,
+		}
+
+		filteredChunks, err := iotaWrapper.VerifyChunkMessagesMatchRecord([]oyster_utils.ChunkData{chunk})
+		if err != nil {
+			oyster_utils.LogIfError(err, nil)
+			continue
+		}
+
+		handleAttachmentResults(filteredChunks, treasure, thresholdTime)
+	}
+}
+
+func handleAttachmentResults(filteredChunks services.FilteredChunk, treasure models.Treasure,
+	thresholdTime time.Time) {
+	var err error
+	var vErr *validate.Errors
+
+	if len(filteredChunks.MatchesTangle) > 0 {
+		treasure.SignedStatus = models.TreasureSignedAndAttachmentVerified
+		vErr, err = models.DB.ValidateAndUpdate(&treasure)
+		logTreasureAttachmentResult("attach_treasure: attachment verified", treasure)
+	} else if len(filteredChunks.DoesNotMatchTangle) > 0 {
+		// Setting it to TreasureAttachError so it gets picked up again by AttachTreasureTransactions
+		treasure.SignedStatus = models.TreasureAttachError
+		vErr, err = models.DB.ValidateAndUpdate(&treasure)
+		logTreasureAttachmentResult("attach_treasure: attachment error", treasure)
+	} else if len(filteredChunks.NotAttached) > 0 {
+		if treasure.UpdatedAt.Before(thresholdTime) {
+			// Setting it to TreasureAttachError so it gets picked up again by AttachTreasureTransactions
+			treasure.SignedStatus = models.TreasureAttachError
+			vErr, err = models.DB.ValidateAndUpdate(&treasure)
+			logTreasureAttachmentResult("attach_treasure: attachment timed out", treasure)
+		}
+	}
+
+	oyster_utils.LogIfValidationError("error updating treasure's SignedStatus to "+
+		models.SignedStatusMap[treasure.SignedStatus]+
+		" TreasureAttachError in attach_treasure", vErr, nil)
+	oyster_utils.LogIfError(err, nil)
+}
+
+func logTreasureAttachmentResult(eventName string, treasure models.Treasure) {
+	oyster_utils.LogToSegment(eventName, analytics.NewProperties().
+		Set("tangle_address", treasure.Address).
+		Set("genesis_hash", treasure.GenesisHash).
+		Set("expected_message", treasure.Message).
+		Set("encryption_index", treasure.EncryptionIndex).
+		Set("index", treasure.Idx))
+}

--- a/jobs/attach_treasure.go
+++ b/jobs/attach_treasure.go
@@ -9,6 +9,7 @@ import (
 	"time"
 )
 
+/*AttachTreasuresToTangle calls attachment and verification methods for treasures*/
 func AttachTreasuresToTangle(iotaWrapper services.IotaService, PrometheusWrapper services.PrometheusService,
 	thresholdTime time.Time) {
 
@@ -19,6 +20,7 @@ func AttachTreasuresToTangle(iotaWrapper services.IotaService, PrometheusWrapper
 	VerifyTreasureTransactions(iotaWrapper, thresholdTime)
 }
 
+/*AttachTreasureTransactions is responsible for attaching the treasures to the tangle*/
 func AttachTreasureTransactions(iotaWrapper services.IotaService) {
 	var vErr *validate.Errors
 	treasuresToAttach, err := models.GetTreasuresToBuryBySignedStatus([]models.SignedStatus{models.TreasureSigned,
@@ -57,6 +59,9 @@ func AttachTreasureTransactions(iotaWrapper services.IotaService) {
 	}
 }
 
+/*VerifyTreasureTransactions verifies the treasures that are supposedly attached to the tangle.
+It will also set treasures to an error state if they have timed out or if what is on the tangle does
+not match our records.*/
 func VerifyTreasureTransactions(iotaWrapper services.IotaService, thresholdTime time.Time) {
 	treasuresToAttach, err := models.GetTreasuresToBuryBySignedStatus([]models.SignedStatus{
 		models.TreasureSignedAndAttached})

--- a/jobs/attach_treasure_test.go
+++ b/jobs/attach_treasure_test.go
@@ -1,0 +1,309 @@
+package jobs_test
+
+import (
+	"github.com/oysterprotocol/brokernode/jobs"
+	"github.com/oysterprotocol/brokernode/models"
+	"github.com/oysterprotocol/brokernode/services"
+	"github.com/oysterprotocol/brokernode/utils"
+	"github.com/pkg/errors"
+	"time"
+)
+
+func (suite *JobsSuite) Test_AttachTreasureTransactions_success() {
+	IotaMock.DoPoW = func(chunks []oyster_utils.ChunkData) error {
+		return nil
+	}
+
+	// create one treasure for each SignedStatus
+	makeOneTreasureOfEachSignedStatus(suite)
+
+	// call method under test
+	jobs.AttachTreasureTransactions(IotaMock)
+
+	/*
+		Expectations:
+			-there will be no treasures with SignedStatus TreasureAttachError
+			-there will be no treasures with SignedStatus TreasureSigned
+			-there will be 3 treasures with SignedStatus TreasureSignedAndAttached. 2 of them
+			are newly assigned and one was created in makeOneTreasureOfEachSignedStatus()
+	*/
+
+	numTreasureAttachError := 0
+	numTreasureSigned := 0
+	numTreasureSignedAndAttached := 0
+
+	treasures := []models.Treasure{}
+	suite.DB.All(&treasures)
+
+	for _, treasure := range treasures {
+		if treasure.SignedStatus == models.TreasureAttachError {
+			numTreasureAttachError++
+		}
+		if treasure.SignedStatus == models.TreasureSigned {
+			numTreasureSigned++
+		}
+		if treasure.SignedStatus == models.TreasureSignedAndAttached {
+			numTreasureSignedAndAttached++
+		}
+	}
+
+	suite.Equal(0, numTreasureAttachError)
+	suite.Equal(0, numTreasureSigned)
+	suite.Equal(3, numTreasureSignedAndAttached)
+}
+
+func (suite *JobsSuite) Test_AttachTreasureTransactions_error() {
+	IotaMock.DoPoW = func(chunks []oyster_utils.ChunkData) error {
+		return errors.New("something went wrong")
+	}
+
+	// create one treasure for each SignedStatus
+	makeOneTreasureOfEachSignedStatus(suite)
+
+	// call method under test
+	jobs.AttachTreasureTransactions(IotaMock)
+
+	/*
+		Expectations:
+			-there will be 2 treasures with SignedStatus TreasureAttachError. 1 was created in
+			makeOneTreasureOfEachSignedStatus() and 1 other will have this status after
+			we call the method under test
+			-there will be no treasures with SignedStatus TreasureSigned
+			-there will be 1 treasures with SignedStatus TreasureSignedAndAttached.  Just the one that
+			we initially created in makeOneTreasureOfEachSignedStatus()
+	*/
+
+	numTreasureAttachError := 0
+	numTreasureSigned := 0
+	numTreasureSignedAndAttached := 0
+
+	treasures := []models.Treasure{}
+	suite.DB.All(&treasures)
+
+	for _, treasure := range treasures {
+		if treasure.SignedStatus == models.TreasureAttachError {
+			numTreasureAttachError++
+		}
+		if treasure.SignedStatus == models.TreasureSigned {
+			numTreasureSigned++
+		}
+		if treasure.SignedStatus == models.TreasureSignedAndAttached {
+			numTreasureSignedAndAttached++
+		}
+	}
+
+	suite.Equal(2, numTreasureAttachError)
+	suite.Equal(0, numTreasureSigned)
+	suite.Equal(1, numTreasureSignedAndAttached)
+}
+
+func (suite *JobsSuite) Test_VerifyTreasureTransactions_error_while_verifying() {
+	IotaMock.VerifyChunkMessagesMatchRecord = func(chunks []oyster_utils.ChunkData) (filteredChunks services.FilteredChunk, err error) {
+		return services.FilteredChunk{
+			MatchesTangle:      []oyster_utils.ChunkData{},
+			NotAttached:        []oyster_utils.ChunkData{},
+			DoesNotMatchTangle: []oyster_utils.ChunkData{},
+		}, errors.New("some error happened")
+	}
+
+	// create one treasure for each SignedStatus
+	makeOneTreasureOfEachSignedStatus(suite)
+
+	// call method under test
+	jobs.VerifyTreasureTransactions(IotaMock, time.Now())
+
+	/*
+		Expectations:
+			-there was an error while verifying so nothing should have changed
+	*/
+
+	oneOfEachStatus := true
+
+	for status := range models.SignedStatusMap {
+		treasures := []models.Treasure{}
+		suite.DB.Where("signed_status = ?", status).All(&treasures)
+		if len(treasures) != 1 {
+			oneOfEachStatus = false
+		}
+	}
+
+	suite.True(oneOfEachStatus)
+}
+
+func (suite *JobsSuite) Test_VerifyTreasureTransactions_success() {
+	IotaMock.VerifyChunkMessagesMatchRecord = func(chunks []oyster_utils.ChunkData) (filteredChunks services.FilteredChunk, err error) {
+		return services.FilteredChunk{
+			MatchesTangle:      chunks,
+			NotAttached:        []oyster_utils.ChunkData{},
+			DoesNotMatchTangle: []oyster_utils.ChunkData{},
+		}, nil
+	}
+
+	// create one treasure for each SignedStatus
+	makeOneTreasureOfEachSignedStatus(suite)
+
+	// call method under test
+	jobs.VerifyTreasureTransactions(IotaMock, time.Now())
+
+	/*
+		Expectations:
+			-there will be 2 treasures with SignedStatus TreasureSignedAndAttachmentVerified. 1 was created in
+			makeOneTreasureOfEachSignedStatus() and 1 other will have this status after
+			we call the method under test
+			-there will be no treasures with SignedStatus TreasureSignedAndAttached
+	*/
+
+	numTreasureSignedAndAttached := 0
+	numTreasureSignedAndAttachmentVerified := 0
+
+	treasures := []models.Treasure{}
+	suite.DB.All(&treasures)
+
+	for _, treasure := range treasures {
+		if treasure.SignedStatus == models.TreasureSignedAndAttachmentVerified {
+			numTreasureSignedAndAttachmentVerified++
+		}
+		if treasure.SignedStatus == models.TreasureSignedAndAttached {
+			numTreasureSignedAndAttached++
+		}
+	}
+
+	suite.Equal(2, numTreasureSignedAndAttachmentVerified)
+	suite.Equal(0, numTreasureSignedAndAttached)
+}
+
+func (suite *JobsSuite) Test_VerifyTreasureTransactions_does_not_match_record() {
+	IotaMock.VerifyChunkMessagesMatchRecord = func(chunks []oyster_utils.ChunkData) (filteredChunks services.FilteredChunk, err error) {
+		return services.FilteredChunk{
+			MatchesTangle:      []oyster_utils.ChunkData{},
+			NotAttached:        []oyster_utils.ChunkData{},
+			DoesNotMatchTangle: chunks,
+		}, nil
+	}
+
+	// create one treasure for each SignedStatus
+	makeOneTreasureOfEachSignedStatus(suite)
+
+	// call method under test
+	jobs.VerifyTreasureTransactions(IotaMock, time.Now())
+
+	/*
+		Expectations:
+			-there will be 2 treasures with SignedStatus TreasureAttachError. 1 was created in
+			makeOneTreasureOfEachSignedStatus() and 1 other will have this status after
+			we call the method under test
+			-there will be no treasures with SignedStatus TreasureSignedAndAttached
+	*/
+
+	numTreasureSignedAndAttached := 0
+	numTreasureAttachError := 0
+
+	treasures := []models.Treasure{}
+	suite.DB.All(&treasures)
+
+	for _, treasure := range treasures {
+		if treasure.SignedStatus == models.TreasureAttachError {
+			numTreasureAttachError++
+		}
+		if treasure.SignedStatus == models.TreasureSignedAndAttached {
+			numTreasureSignedAndAttached++
+		}
+	}
+
+	suite.Equal(2, numTreasureAttachError)
+	suite.Equal(0, numTreasureSignedAndAttached)
+}
+
+func (suite *JobsSuite) Test_VerifyTreasureTransactions_not_attached_not_timed_out() {
+	IotaMock.VerifyChunkMessagesMatchRecord = func(chunks []oyster_utils.ChunkData) (filteredChunks services.FilteredChunk, err error) {
+		return services.FilteredChunk{
+			MatchesTangle:      []oyster_utils.ChunkData{},
+			NotAttached:        chunks,
+			DoesNotMatchTangle: []oyster_utils.ChunkData{},
+		}, nil
+	}
+
+	// create one treasure for each SignedStatus
+	makeOneTreasureOfEachSignedStatus(suite)
+
+	// call method under test
+	jobs.VerifyTreasureTransactions(IotaMock, time.Now().Add(-1*time.Hour))
+
+	/*
+		Expectations:
+			-nothing will have changed because although the chunk is not attached, it is also
+			not yet timed out
+	*/
+
+	oneOfEachStatus := true
+
+	for status := range models.SignedStatusMap {
+		treasures := []models.Treasure{}
+		suite.DB.Where("signed_status = ?", status).All(&treasures)
+		if len(treasures) != 1 {
+			oneOfEachStatus = false
+		}
+	}
+
+	suite.True(oneOfEachStatus)
+}
+
+func (suite *JobsSuite) Test_VerifyTreasureTransactions_not_attached_timed_out() {
+	IotaMock.VerifyChunkMessagesMatchRecord = func(chunks []oyster_utils.ChunkData) (filteredChunks services.FilteredChunk, err error) {
+		return services.FilteredChunk{
+			MatchesTangle:      []oyster_utils.ChunkData{},
+			NotAttached:        chunks,
+			DoesNotMatchTangle: []oyster_utils.ChunkData{},
+		}, nil
+	}
+
+	// create one treasure for each SignedStatus
+	makeOneTreasureOfEachSignedStatus(suite)
+
+	// call method under test
+	jobs.VerifyTreasureTransactions(IotaMock, time.Now().Add(1*time.Hour))
+
+	/*
+		Expectations:
+			-the chunk is not attached and has timed out, so there will be 2 treasures with
+			SignedStatus TreasureAttachError. 1 was created in makeOneTreasureOfEachSignedStatus()
+			and 1 other will have this status after we call the method under test
+			-there will be no treasures with SignedStatus TreasureSignedAndAttached
+	*/
+
+	numTreasureSignedAndAttached := 0
+	numTreasureAttachError := 0
+
+	treasures := []models.Treasure{}
+	suite.DB.All(&treasures)
+
+	for _, treasure := range treasures {
+		if treasure.SignedStatus == models.TreasureAttachError {
+			numTreasureAttachError++
+		}
+		if treasure.SignedStatus == models.TreasureSignedAndAttached {
+			numTreasureSignedAndAttached++
+		}
+	}
+
+	suite.Equal(2, numTreasureAttachError)
+	suite.Equal(0, numTreasureSignedAndAttached)
+}
+
+func makeOneTreasureOfEachSignedStatus(suite *JobsSuite) {
+
+	generateTreasuresToBury(suite, len(models.SignedStatusMap), models.PRLWaiting)
+
+	treasures := []models.Treasure{}
+	suite.DB.All(&treasures)
+	suite.Equal(len(models.SignedStatusMap), len(treasures))
+
+	var i = 0
+	for status := range models.SignedStatusMap {
+		treasures[i].SignedStatus = status
+		vErr, err := suite.DB.ValidateAndSave(&treasures[i])
+		suite.Nil(err)
+		suite.False(vErr.HasAny())
+		i++
+	}
+}

--- a/jobs/bury_treasure_addresses_test.go
+++ b/jobs/bury_treasure_addresses_test.go
@@ -579,6 +579,8 @@ func (suite *JobsSuite) Test_PurgeFinishedTreasure_gen_hash_ready() {
 	suite.Equal(3, len(allTreasures))
 
 	for _, treasure := range allTreasures {
+		treasure.SignedStatus = models.TreasureSignedAndAttachmentVerified
+		suite.DB.ValidateAndUpdate(&treasure)
 		suite.DB.ValidateAndCreate(&models.StoredGenesisHash{
 			GenesisHash:    treasure.GenesisHash,
 			TreasureStatus: models.TreasureBuried,
@@ -602,6 +604,8 @@ func (suite *JobsSuite) Test_PurgeFinishedTreasure_gen_hash_not_ready() {
 	suite.Equal(3, len(allTreasures))
 
 	for _, treasure := range allTreasures {
+		treasure.SignedStatus = models.TreasureSignedAndAttachmentVerified
+		suite.DB.ValidateAndUpdate(&treasure)
 		suite.DB.ValidateAndCreate(&models.StoredGenesisHash{
 			GenesisHash:    treasure.GenesisHash,
 			TreasureStatus: models.TreasurePending,

--- a/jobs/job_runner_test.go
+++ b/jobs/job_runner_test.go
@@ -37,6 +37,9 @@ func (suite *JobsSuite) SetupTest() {
 	*/
 
 	IotaMock = services.IotaService{
+		DoPoW: func(chunks []oyster_utils.ChunkData) error {
+			return nil
+		},
 		SendChunksToChannel: func(chunks []oyster_utils.ChunkData, channel *models.ChunkChannel) {
 
 		},

--- a/models/treasure.go
+++ b/models/treasure.go
@@ -224,6 +224,7 @@ func GetTreasuresToBuryByPRLStatusAndUpdateTime(prlStatuses []PRLStatus, thresho
 	return treasureRowsToReturn, nil
 }
 
+/*GetTreasuresToBuryBySignedStatus gets all the treasures that matched the signed statuses passed in*/
 func GetTreasuresToBuryBySignedStatus(signedStatuses []SignedStatus) ([]Treasure, error) {
 	treasureRowsToReturn := make([]Treasure, 0)
 	for _, status := range signedStatuses {
@@ -260,6 +261,7 @@ func (t *Treasure) DecryptTreasureEthKey() string {
 	return hex.EncodeToString(decryptedKey)
 }
 
+/*GetTreasuresByGenesisHashAndIndexes gets treasures that match the genesis hash and indexes passed in*/
 func GetTreasuresByGenesisHashAndIndexes(genesisHash string, indexes []int) ([]Treasure, error) {
 	// indexes is the actual index of the treasure ( 0, 1,000,000, etc.), NOT the encryption index
 

--- a/models/treasure.go
+++ b/models/treasure.go
@@ -271,23 +271,22 @@ func GetTreasuresByGenesisHashAndIndexes(genesisHash string, indexes []int) ([]T
 	if len(indexes) == 0 {
 		err = DB.Where("genesis_hash = ?", genesisHash).All(&treasures)
 		return treasures, err
-	} else {
-		for _, index := range indexes {
-			treasure := []Treasure{}
+	}
+	for _, index := range indexes {
+		treasure := []Treasure{}
 
-			err = DB.RawQuery("SELECT * FROM treasures WHERE genesis_hash = ? AND "+
-				"idx = ?",
-				genesisHash,
-				index).All(&treasure)
+		err = DB.RawQuery("SELECT * FROM treasures WHERE genesis_hash = ? AND "+
+			"idx = ?",
+			genesisHash,
+			index).All(&treasure)
 
-			if len(treasure) > 1 {
-				err = errors.New("there should only be one treasure with a particular genesis hash and index!")
-				break
-			} else if len(treasure) == 1 {
-				treasures = append(treasures, treasure[0])
-			} else if err != nil {
-				break
-			}
+		if len(treasure) > 1 {
+			err = errors.New("there should only be one treasure with a particular genesis hash and index")
+			break
+		} else if len(treasure) == 1 {
+			treasures = append(treasures, treasure[0])
+		} else if err != nil {
+			break
 		}
 	}
 

--- a/models/treasure.go
+++ b/models/treasure.go
@@ -3,6 +3,7 @@ package models
 import (
 	"encoding/hex"
 	"encoding/json"
+	"github.com/pkg/errors"
 	"math/big"
 	"time"
 
@@ -154,10 +155,8 @@ func (t *Treasure) BeforeCreate(tx *pop.Connection) error {
 		t.PRLStatus = PRLWaiting
 	}
 
-	if len(t.Message) > 81 {
-		// don't really need full message, just something known to
-		// the broker that we can hash and then use for encryption
-		t.Message = t.Message[0:81]
+	if t.SignedStatus == 0 {
+		t.SignedStatus = TreasureNotSet
 	}
 
 	t.EncryptTreasureEthKey()
@@ -225,6 +224,22 @@ func GetTreasuresToBuryByPRLStatusAndUpdateTime(prlStatuses []PRLStatus, thresho
 	return treasureRowsToReturn, nil
 }
 
+func GetTreasuresToBuryBySignedStatus(signedStatuses []SignedStatus) ([]Treasure, error) {
+	treasureRowsToReturn := make([]Treasure, 0)
+	for _, status := range signedStatuses {
+		treasureToBury := []Treasure{}
+		err := DB.RawQuery("SELECT * FROM treasures WHERE signed_status = ? LIMIT ?",
+			status,
+			maxNumSimultaneousTreasureTxs).All(&treasureToBury)
+		if err != nil {
+			oyster_utils.LogIfError(err, nil)
+			return treasureToBury, err
+		}
+		treasureRowsToReturn = append(treasureRowsToReturn, treasureToBury...)
+	}
+	return treasureRowsToReturn, nil
+}
+
 func GetAllTreasuresToBury() ([]Treasure, error) {
 	allTreasures := []Treasure{}
 	err := DB.RawQuery("SELECT * FROM treasures").All(&allTreasures)
@@ -243,4 +258,37 @@ func (t *Treasure) DecryptTreasureEthKey() string {
 	hashedAddress := oyster_utils.HashHex(hex.EncodeToString([]byte(t.Address)), sha3.New256())
 	decryptedKey := oyster_utils.Decrypt(hashedMessage, t.ETHKey, hashedAddress)
 	return hex.EncodeToString(decryptedKey)
+}
+
+func GetTreasuresByGenesisHashAndIndexes(genesisHash string, indexes []int) ([]Treasure, error) {
+	// indexes is the actual index of the treasure ( 0, 1,000,000, etc.), NOT the encryption index
+
+	var err error
+	treasures := []Treasure{}
+
+	if len(indexes) == 0 {
+		err = DB.Where("genesis_hash = ?", genesisHash).All(&treasures)
+		return treasures, err
+	} else {
+		for _, index := range indexes {
+			treasure := []Treasure{}
+
+			err = DB.RawQuery("SELECT * FROM treasures WHERE genesis_hash = ? AND "+
+				"idx = ?",
+				genesisHash,
+				index).All(&treasure)
+
+			if len(treasure) > 1 {
+				err = errors.New("there should only be one treasure with a particular genesis hash and index!")
+				break
+			} else if len(treasure) == 1 {
+				treasures = append(treasures, treasure[0])
+			} else if err != nil {
+				break
+			}
+		}
+	}
+
+	oyster_utils.LogIfError(err, nil)
+	return treasures, err
 }

--- a/models/treasure_test.go
+++ b/models/treasure_test.go
@@ -90,6 +90,89 @@ func (suite *ModelSuite) Test_EncryptAndDecryptEthPrivateKey() {
 	suite.Equal(ethKey, decryptedKey)
 }
 
+func (suite *ModelSuite) Test_GetTreasuresToBuryBySignedStatus() {
+	makeOneTreasureOfEachSignedStatus(suite)
+
+	allSignedStatuses := []models.SignedStatus{}
+
+	for key := range models.SignedStatusMap {
+		allSignedStatuses = append(allSignedStatuses, key)
+	}
+
+	suite.NotEqual(0, len(allSignedStatuses))
+	suite.Equal(len(models.SignedStatusMap), len(allSignedStatuses))
+
+	treasures, err := models.GetTreasuresToBuryBySignedStatus(allSignedStatuses)
+	suite.Nil(err)
+
+	// we created one of each signed status so make sure the number of
+	// treasures matches the length of allSignedStatuses
+	suite.Equal(len(allSignedStatuses), len(treasures))
+
+	// test that it can pluck out all treasures of just one type
+	treasures, err = models.GetTreasuresToBuryBySignedStatus([]models.SignedStatus{
+		models.TreasureSigned})
+	suite.Nil(err)
+
+	suite.Equal(1, len(treasures))
+
+	// change all treasures to the same type
+	for _, treasure := range treasures {
+		treasure.SignedStatus = models.TreasureSigned
+		suite.DB.ValidateAndSave(&treasure)
+	}
+
+	startingTreasureLength := len(treasures)
+
+	// for good measure, make the same call again and make sure the length of the
+	// returned array is the length of all the treasures
+	treasures, err = models.GetTreasuresToBuryBySignedStatus([]models.SignedStatus{
+		models.TreasureSigned})
+	suite.Nil(err)
+
+	suite.Equal(startingTreasureLength, len(treasures))
+}
+
+func (suite *ModelSuite) Test_GetTreasuresByGenesisHashAndIndexes() {
+	// make two sets of treasures so they will have different genesis hashes
+	makeOneTreasureOfEachSignedStatus(suite)
+	makeOneTreasureOfEachSignedStatus(suite)
+
+	treasures := []models.Treasure{}
+	genHashes := make(map[string]string)
+
+	suite.DB.All(&treasures)
+
+	for _, treasure := range treasures {
+		genHashes[treasure.GenesisHash] = treasure.GenesisHash
+		if len(genHashes) == 2 {
+			break
+		}
+	}
+
+	suite.Equal(2, len(genHashes))
+
+	for genHash := range genHashes {
+		// Check that we can retrieve 1 treasure and that the genesis hash and index is what we expect
+		treasures, err := models.GetTreasuresByGenesisHashAndIndexes(genHash, []int{0})
+		suite.Nil(err)
+		suite.Equal(1, len(treasures))
+		suite.True(treasures[0].GenesisHash == genHash && treasures[0].Idx == 0)
+
+		// Check that we can retrieve multiple treasures and that the genesis hashes and indexes are
+		// what we expect
+		treasures, err = models.GetTreasuresByGenesisHashAndIndexes(genHash, []int{
+			0, 2000000})
+		suite.Nil(err)
+		suite.Equal(2, len(treasures))
+		suite.True(treasures[0].GenesisHash == genHash &&
+			treasures[0].Idx == 0 || treasures[0].Idx == 2000000)
+		suite.True(treasures[1].GenesisHash == genHash &&
+			treasures[1].Idx == 0 || treasures[1].Idx == 2000000)
+		suite.True(treasures[1].Idx != treasures[0].Idx)
+	}
+}
+
 func generateTreasuresToBuryOfEachStatus(suite *ModelSuite, numToCreateOfEachStatus int) {
 	allStatuses := []models.PRLStatus{
 		models.PRLWaiting,
@@ -111,17 +194,22 @@ func generateTreasuresToBuryOfEachStatus(suite *ModelSuite, numToCreateOfEachSta
 
 func generateTreasuresToBury(suite *ModelSuite, numToCreateOfEachStatus int, status models.PRLStatus) {
 	prlAmount := big.NewInt(500000000000000000)
+
+	genesisHash := oyster_utils.RandSeq(6, []rune("abcdef0123456789"))
+
 	for i := 0; i < numToCreateOfEachStatus; i++ {
 		ethAddr, key, _ := eth_gateway.EthWrapper.GenerateEthAddr()
 		iotaAddr := oyster_utils.RandSeq(81, oyster_utils.TrytesAlphabet)
 		iotaMessage := oyster_utils.RandSeq(10, oyster_utils.TrytesAlphabet)
 
 		treasureToBury := models.Treasure{
-			PRLStatus: status,
-			ETHAddr:   ethAddr.Hex(),
-			ETHKey:    key,
-			Message:   iotaMessage,
-			Address:   iotaAddr,
+			GenesisHash: genesisHash,
+			PRLStatus:   status,
+			ETHAddr:     ethAddr.Hex(),
+			ETHKey:      key,
+			Message:     iotaMessage,
+			Address:     iotaAddr,
+			Idx:         int64(i * 1000000),
 		}
 
 		treasureToBury.SetPRLAmount(prlAmount)
@@ -129,5 +217,21 @@ func generateTreasuresToBury(suite *ModelSuite, numToCreateOfEachStatus int, sta
 		vErr, err := suite.DB.ValidateAndCreate(&treasureToBury)
 		suite.Nil(err)
 		suite.False(vErr.HasAny())
+	}
+}
+
+func makeOneTreasureOfEachSignedStatus(suite *ModelSuite) {
+	generateTreasuresToBury(suite, len(models.SignedStatusMap), models.PRLWaiting)
+
+	treasures := []models.Treasure{}
+	suite.DB.All(&treasures)
+
+	var i = 0
+	for status := range models.SignedStatusMap {
+		treasures[i].SignedStatus = status
+		vErr, err := suite.DB.ValidateAndSave(&treasures[i])
+		suite.Nil(err)
+		suite.False(vErr.HasAny())
+		i++
 	}
 }

--- a/services/prometheus.go
+++ b/services/prometheus.go
@@ -47,6 +47,7 @@ type PrometheusService struct {
 	HistogramProcessPaidSessions                   *prometheus.HistogramVec
 	HistogramCheckAllDataIsReady                   *prometheus.HistogramVec
 	HistogramUpdateMsgStatus                       *prometheus.HistogramVec
+	HistogramAttachTreasuresToTangle               *prometheus.HistogramVec
 	HistogramBuryTreasureAddresses                 *prometheus.HistogramVec
 	HistogramProcessUnassignedChunks               *prometheus.HistogramVec
 	HistogramPurgeCompletedSessions                *prometheus.HistogramVec
@@ -77,6 +78,7 @@ func init() {
 	histogramProcessPaidSessions := prepareHistogram("process_paid_sessions_seconds", "HistogramProcessPaidSessions", "code")
 	histogramCheckAllDataIsReady := prepareHistogram("check_all_data_is_ready_seconds", "HistogramCheckAllDataIsReady", "code")
 	histogramUpdateMsgStatus := prepareHistogram("update_msg_status_seconds", "HistogramUpdateMsgStatus", "code")
+	histogramAttachTreasuresToTangle := prepareHistogram("attach_treasures_to_tangle_seconds", "HistogramAttachTreasuresToTangle", "code")
 	histogramBuryTreasureAddresses := prepareHistogram("bury_treasure_addresses_seconds", "HistogramBuryTreasureAddresses", "code")
 	histogramProcessUnassignedChunks := prepareHistogram("process_unassigned_chunks_seconds", "HistogramProcessUnassignedChunks", "code")
 	histogramPurgeCompletedSessions := prepareHistogram("purge_completed_sessions_seconds", "HistogramPurgeCompletedSessions", "code")
@@ -110,6 +112,7 @@ func init() {
 		HistogramProcessPaidSessions:                   histogramProcessPaidSessions,
 		HistogramCheckAllDataIsReady:                   histogramCheckAllDataIsReady,
 		HistogramUpdateMsgStatus:                       histogramUpdateMsgStatus,
+		HistogramAttachTreasuresToTangle:               histogramAttachTreasuresToTangle,
 		HistogramBuryTreasureAddresses:                 histogramBuryTreasureAddresses,
 		HistogramProcessUnassignedChunks:               histogramProcessUnassignedChunks,
 		HistogramPurgeCompletedSessions:                histogramPurgeCompletedSessions,


### PR DESCRIPTION
-adds attach_treasure job and tests but does not yet add it to the job runner
-only purge a treasure in bury_treasure_addresses if we have attached and verified it
-add methods to treasures.go to get treasures by signed_status or by genesis hash + index.  Also adds tests.  