### PR TITLE
Update Create/CreateBeta method

### DIFF
--- a/actions/v3/upload_sessions.go
+++ b/actions/v3/upload_sessions.go
@@ -292,9 +292,9 @@ func saveTreasureMapForS3(u *models.UploadSession, treasureIndexA []int, treasur
 		u.MakeTreasureIdxMap(mergedIndexes, privateKeys)
 
 		// Verify that MakeTreasureIdxMap is correct. Otherwise, regenerate it again.
-		treasureIndexes, _ := alphaSession.GetTreasureIndexes()
-		if alphaSession.TreasureStatus == models.TreasureInDataMapPending &&
-			alphaSession.TreasureIdxMap.Valid && alphaSession.TreasureIdxMap.String != "" &&
+		treasureIndexes, _ := u.GetTreasureIndexes()
+		if u.TreasureStatus == models.TreasureInDataMapPending &&
+			u.TreasureIdxMap.Valid && u.TreasureIdxMap.String != "" &&
 			len(treasureIndexes) == len(mergedIndexes) {
 			break
 		}

--- a/actions/v3/upload_sessions.go
+++ b/actions/v3/upload_sessions.go
@@ -86,7 +86,8 @@ func (usr *UploadSessionResourceV3) Update(c buffalo.Context) error {
 		return c.Error(400, errors.New("Using the wrong endpoint. This endpoint is for V3 only"))
 	}
 
-	objectKey := oyster_utils.GetObjectKeyForData(uploadSession.GenesisHash, req.Chunks[0].Idx, BatchSize)
+	isReverseIteration := uploadSession.Type == models.SessionTypeBeta
+	objectKey := oyster_utils.GetObjectKeyForData(uploadSession.GenesisHash, req.Chunks[0].Idx, uploadSession.NumChunks, isReverseIteration, BatchSize)
 
 	var data []byte
 	if data, err = json.Marshal(req.Chunks); err != nil {

--- a/actions/v3/upload_sessions.go
+++ b/actions/v3/upload_sessions.go
@@ -33,6 +33,7 @@ type uploadSessionCreateReqV3 struct {
 	FileSizeBytes        uint64         `json:"fileSizeBytes"` // This is Trytes instead of Byte
 	BetaIP               string         `json:"betaIp"`
 	StorageLengthInYears int            `json:"storageLengthInYears"`
+	AlphaTreasureIndexes []int          `json:"alphaTreasureIndexes"`
 	Invoice              models.Invoice `json:"invoice"`
 	Version              uint32         `json:"version"`
 }
@@ -44,9 +45,18 @@ type uploadSessionCreateBetaResV3 struct {
 }
 
 type uploadSessionCreateResV3 struct {
-	ID            string `json:"id"`
-	BetaSessionID string `json:"betaSessionId"`
-	BatchSize     int    `json:"batchSize"`
+	ID            string         `json:"id"`
+	BetaSessionID string         `json:"betaSessionId"`
+	BatchSize     int            `json:"batchSize"`
+	Invoice       models.Invoice `json:"invoice"`
+}
+
+/*uploadSessionConfig represents the general configuration that other client could understand.*/
+type uploadSessionConfig struct {
+	BatchSize        int    `json:"batchSize"`        // Represent each data contain not more number of field.
+	FileSizeBytes    uint64 `json:"fileSizeBytes"`    // Represent the total file size.
+	NumChunks        int    `json:"numChunks"`        // Represent total number of chunks.
+	ReserveIteration bool   `json:"reserveIteration"` // Represent whether iterate it from the beginning to end or end to the beginning.
 }
 
 var NumChunksLimit = -1 //unlimited
@@ -66,8 +76,7 @@ func (usr *UploadSessionResourceV3) Update(c buffalo.Context) error {
 
 	uploadSession := &models.UploadSession{}
 	if err = models.DB.Find(uploadSession, c.Param("id")); err != nil {
-		oyster_utils.LogIfError(err, nil)
-		return c.Error(500, err)
+		return c.Error(500, oyster_utils.LogIfError(err, nil))
 	}
 	if uploadSession == nil {
 		return c.Error(400, fmt.Errorf("Error in finding session for id %v", c.Param("id")))
@@ -77,16 +86,14 @@ func (usr *UploadSessionResourceV3) Update(c buffalo.Context) error {
 		return c.Error(400, errors.New("Using the wrong endpoint. This endpoint is for V3 only"))
 	}
 
-	fileIndex := req.Chunks[0].Idx / BatchSize
-	objectKey := fmt.Sprintf("%v/%v", uploadSession.GenesisHash, fileIndex)
+	objectKey := oyster_utils.GetObjectKeyForData(uploadSession.GenesisHash, req.Chunks[0].Idx, BatchSize)
 
 	var data []byte
 	if data, err = json.Marshal(req.Chunks); err != nil {
-		return c.Error(500, fmt.Errorf("Unable to marshal ChunkReq to JSON with err %v", err))
+		return c.Error(500, oyster_utils.LogIfError(fmt.Errorf("Unable to marshal ChunkReq to JSON with err %v", err), nil))
 	}
 	if err = setDefaultBucketObject(objectKey, string(data)); err != nil {
-		oyster_utils.LogIfError(err, nil)
-		return c.Error(500, fmt.Errorf("Unable to store data to S3 with err: %v", err))
+		return c.Error(500, oyster_utils.LogIfError(fmt.Errorf("Unable to store data to S3 with err: %v", err), nil))
 	}
 
 	return c.Render(202, actions_utils.Render.JSON(map[string]bool{"success": true}))
@@ -114,6 +121,16 @@ func (usr *UploadSessionResourceV3) Create(c buffalo.Context) error {
 		StorageMethod:        models.StorageMethodS3,
 	}
 
+	if vErr, err := alphaSession.StartUploadSession(); err != nil || vErr.HasAny() {
+		return c.Error(400, fmt.Errorf("StartUploadSession error: %v and validation error: %v", err, vErr))
+	}
+
+	invoice := alphaSession.GetInvoice()
+
+	// Mutates this because copying in golang sucks...
+	req.Invoice = invoice
+	req.AlphaTreasureIndexes = oyster_utils.GenerateInsertedIndexesForPearl(oyster_utils.ConvertToByte(req.FileSizeBytes))
+
 	hasBeta := req.BetaIP != ""
 	var betaSessionID = ""
 	if hasBeta {
@@ -124,17 +141,27 @@ func (usr *UploadSessionResourceV3) Create(c buffalo.Context) error {
 
 		betaSessionID = betaSessionRes.ID
 		alphaSession.ETHAddrBeta = nulls.NewString(betaSessionRes.ETHAddr)
+
+		if err := saveTreasureMapForS3(&alphaSession, req.AlphaTreasureIndexes, betaSessionRes.TreasureIndexes); err != nil {
+			return c.Error(500, err)
+		}
+
+		if err := models.DB.Save(&alphaSession); err != nil {
+			return c.Error(400, oyster_utils.LogIfError(err, nil))
+		}
 	}
 
-	if err := models.DB.Save(&alphaSession); err != nil {
-		oyster_utils.LogIfError(err, nil)
-		return c.Error(400, err)
+	if err := saveConfigForS3(alphaSession); err != nil {
+		return c.Error(500, err)
 	}
+
+	models.NewBrokerBrokerTransaction(&alphaSession)
 
 	res := uploadSessionCreateResV3{
 		ID:            alphaSession.ID.String(),
 		BetaSessionID: betaSessionID,
 		BatchSize:     BatchSize,
+		Invoice:       invoice,
 	}
 
 	return c.Render(200, actions_utils.Render.JSON(res))
@@ -164,12 +191,29 @@ func (usr *UploadSessionResourceV3) CreateBeta(c buffalo.Context) error {
 		StorageMethod:        models.StorageMethodS3,
 	}
 
-	if err := models.DB.Save(&u); err != nil {
-		return c.Error(400, err)
+	if vErr, err := u.StartUploadSession(); err != nil || vErr.HasAny() {
+		return c.Error(400, fmt.Errorf("Can't startUploadSession with validation error: %v and err: %v", vErr, err))
 	}
 
+	betaTreasureIndexes := oyster_utils.GenerateInsertedIndexesForPearl(oyster_utils.ConvertToByte(req.FileSizeBytes))
+	if err := saveTreasureMapForS3(&u, req.AlphaTreasureIndexes, betaTreasureIndexes); err != nil {
+		return c.Error(500, err)
+	}
+
+	if err := models.DB.Save(&u); err != nil {
+		return c.Error(500, err)
+	}
+
+	if err := saveConfigForS3(u); err != nil {
+		return c.Error(500, err)
+	}
+
+	models.NewBrokerBrokerTransaction(&u)
+
 	res := uploadSessionCreateBetaResV3{
-		ID: u.ID.String(),
+		ID:              u.ID.String(),
+		TreasureIndexes: betaTreasureIndexes,
+		ETHAddr:         u.ETHAddrBeta.String,
 	}
 
 	return c.Render(200, actions_utils.Render.JSON(res))
@@ -218,4 +262,52 @@ func sendBetaWithUploadRequest(req uploadSessionCreateReqV3) (uploadSessionCreat
 	betaURL := req.BetaIP + ":3000/api/v3/upload-sessions/beta"
 	err := oyster_utils.SendHttpReq(betaURL, req, betaSessionRes)
 	return betaSessionRes, err
+}
+
+/*saveTreasureMapForS3 saves treasure keys as JSON format into S3.*/
+func saveTreasureMapForS3(u *models.UploadSession, treasureIndexA []int, treasureIndexB []int) error {
+	mergedIndexes, err := oyster_utils.MergeIndexes(treasureIndexA, treasureIndexB,
+		oyster_utils.FileSectorInChunkSize, u.NumChunks)
+	if err != nil {
+		return err
+	}
+
+	if len(mergedIndexes) == 0 {
+		if oyster_utils.BrokerMode != oyster_utils.TestModeNoTreasure {
+			return oyster_utils.LogIfError(errors.New("no indexes selected for treasure"), nil)
+		}
+		return nil
+	}
+
+	for {
+		privateKeys, err := EthWrapper.GenerateKeys(len(mergedIndexes))
+		if err != nil {
+			return oyster_utils.LogIfError(errors.New("Could not generate eth keys: "+err.Error()), nil)
+		}
+		if len(mergedIndexes) != len(privateKeys) {
+			return oyster_utils.LogIfError(errors.New("privateKeys and mergedIndexes should have the same length"), nil)
+		}
+		// Update treasureId
+		u.MakeTreasureIdxMap(mergedIndexes, privateKeys)
+	}
+	if !u.TreasureIdxMap.Valid || u.TreasureIdxMap.String == "" {
+		return oyster_utils.LogIfError(errors.New("Not treasure was included in the UploadSession"), nil)
+	}
+
+	return setDefaultBucketObject(oyster_utils.GetObjectKeyForTreasure(u.GenesisHash), u.TreasureIdxMap.String)
+}
+
+/*saveConfigForS3 saves uploadSession config to S3 endpoint so that Lamdba function could read it.*/
+func saveConfigForS3(u models.UploadSession) error {
+	config := uploadSessionConfig{
+		BatchSize:        BatchSize,
+		FileSizeBytes:    u.FileSizeBytes,
+		NumChunks:        u.NumChunks,
+		ReserveIteration: u.Type == models.SessionTypeBeta,
+	}
+	data, err := json.Marshal(config)
+	if err != nil {
+		return oyster_utils.LogIfError(err, nil)
+	}
+	return setDefaultBucketObject(oyster_utils.GetObjectKeyForConfig(u.GenesisHash), string(data))
 }

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -400,11 +400,23 @@ func GetObjectKeyForTreasure(genesisHash string) string {
 }
 
 /*GetObjectKeyForData will return object key for particular data. startIndex is the smallest index in data. */
-func GetObjectKeyForData(genesisHash string, startIndex int, batchSize int) string {
-	return fmt.Sprintf("%v/%v/%v", genesisHash, "data", startIndex%batchSize)
+func GetObjectKeyForData(genesisHash string, startIndex int, totalCount int, isReserveIteration bool, batchSize int) string {
+	index := 0
+	if isReserveIteration {
+		index = (totalCount - 1 - startIndex) / batchSize
+	} else {
+		index = startIndex / batchSize
+	}
+	return fmt.Sprintf("%v/%v/%v", genesisHash, "data", index)
 }
 
 /*GetObjectKeyForHash will return object key for particular data. startIndex is the smallest index in data. */
-func GetObjectKeyForHash(genesisHash string, startIndex int, batchSize int) string {
-	return fmt.Sprintf("%v/%v/%v", genesisHash, "hash", startIndex%batchSize)
+func GetObjectKeyForHash(genesisHash string, startIndex int, totalCount int, isReserveIteration bool, batchSize int) string {
+	index := 0
+	if isReserveIteration {
+		index = (totalCount - 1 - startIndex) / batchSize
+	} else {
+		index = startIndex / batchSize
+	}
+	return fmt.Sprintf("%v/%v/%v", genesisHash, "hash", index)
 }

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -407,6 +407,7 @@ func GetObjectKeyForData(genesisHash string, startIndex int, totalCount int, isR
 	} else {
 		index = startIndex / batchSize
 	}
+
 	return fmt.Sprintf("%v/%v/%v", genesisHash, "data", index)
 }
 
@@ -418,5 +419,6 @@ func GetObjectKeyForHash(genesisHash string, startIndex int, totalCount int, isR
 	} else {
 		index = startIndex / batchSize
 	}
+
 	return fmt.Sprintf("%v/%v/%v", genesisHash, "hash", index)
 }


### PR DESCRIPTION
Saving the following data into S3 so that lambda could process it.

1. Data format as gensis_hash/data/file_index. File contains a BatchSize of data.
2. Genesis Hash as gensis_hash/hash/file_index.
3. Each data and genesis hash is 1:1 mapping. And there is not treasure within.
4. Config data(single file) so that lambda knows how to process it.
5. Treasure map data (single file).

When lambda attach to the data, it would first download config data and treasure map.
And then start to upload each data/genesis hash in pairs.
When arrive to a particular index that need to skip (for inserting the treasure), Lambda will then insert it with treasure rather than the data.